### PR TITLE
Prepare for Scala 2.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ organization := "edu.berkeley.cs"
 version := "1.2-SNAPSHOT"
 name := "Chisel.iotesters"
 
-scalaVersion := "2.11.7"
+scalaVersion := "2.11.11"
 
 // Provide a managed dependency on X if -DXVersion="" is supplied on the command line.
 // The following are the default development versions, not the "release" versions.
@@ -16,9 +16,9 @@ libraryDependencies ++= Seq("chisel3","firrtl","firrtl-interpreter").map { dep: 
     "edu.berkeley.cs" %% dep % sys.props.getOrElse(dep + "Version", defaultVersions(dep))
 }
 
-libraryDependencies ++= Seq("org.scalatest" %% "scalatest" % "2.2.4",
-                            "org.scalacheck" %% "scalacheck" % "1.12.4",
-                            "com.github.scopt" %% "scopt" % "3.4.0")
+libraryDependencies ++= Seq("org.scalatest" %% "scalatest" % "3.0.1",
+                            "org.scalacheck" %% "scalacheck" % "1.13.4",
+                            "com.github.scopt" %% "scopt" % "3.5.0")
     
 publishMavenStyle := true
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.12
+sbt.version = 0.13.15

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 logLevel := Level.Warn
 
-addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.7.0")
+addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
 

--- a/src/main/scala/chisel3/iotesters/ChiselSpec.scala
+++ b/src/main/scala/chisel3/iotesters/ChiselSpec.scala
@@ -30,7 +30,7 @@ class ChiselPropSpec extends PropSpec with ChiselRunners with PropertyChecks {
 
   // Constrain the default number of instances generated for every use of forAll.
   implicit override val generatorDrivenConfig =
-    PropertyCheckConfig(minSuccessful = 8, minSize = 1, maxSize = 4)
+    PropertyCheckConfiguration(minSuccessful = 8, minSize = 1, sizeRange = 3)
 
   // Generator for small positive integers.
   val smallPosInts = Gen.choose(1, 4)


### PR DESCRIPTION
bump versions; replace PropertyCheckConfig with PropertyCheckConfiguration.
This also address issue #143.