### PR TITLE
pass testerBackend argument, not hardcoded firrtl backend to PokeTester trait

### DIFF
--- a/src/main/scala/chisel3/iotesters/ChiselPokeSpec.scala
+++ b/src/main/scala/chisel3/iotesters/ChiselPokeSpec.scala
@@ -112,7 +112,7 @@ trait PokeTester extends ChiselPokeTesterUtils {
 
   def test[T <: Module](dutGen: => T, testerBackend: TesterBackend=FirrtlInterpreterBackend)(block: (InnerTester, T) => Unit) {
     val options = new TesterOptionsManager
-    test(dutGen, FirrtlInterpreterBackend, options)(block)
+    test(dutGen, testerBackend, options)(block)
   }
 }
 


### PR DESCRIPTION
Small one-liner fix to ChiselPokeSpec.scala.  Fix PokeTester trait.