### PR TITLE
Don't add 0-width wires to verilated c++

### DIFF
--- a/src/main/scala/chisel3/iotesters/VerilatorBackend.scala
+++ b/src/main/scala/chisel3/iotesters/VerilatorBackend.scala
@@ -42,7 +42,9 @@ object VerilatorCppHarnessGenerator {
     val codeBuffer = new StringBuilder
 
     def pushBack(vector: String, pathName: String, width: BigInt) {
-      if (width <= 8) {
+      if (width == 0) {
+        // Do nothing- 0 width wires are removed
+      } else if (width <= 8) {
         codeBuffer.append(s"        sim_data.$vector.push_back(new VerilatorCData(&($pathName)));\n")
       } else if (width <= 16) {
         codeBuffer.append(s"        sim_data.$vector.push_back(new VerilatorSData(&($pathName)));\n")

--- a/src/test/scala/verilator/Verilator.scala
+++ b/src/test/scala/verilator/Verilator.scala
@@ -21,4 +21,9 @@ class VerilatorTest extends FlatSpec with Matchers {
       )
       chiselMain(args, () => new doohickey())
     }
+  it should "be able to deal with zero-width wires" in {
+      chisel3.iotesters.Driver.execute(Array("--backend-name", "verilator"), () => new ZeroWidthIOModule) {
+          c => new ZeroWidthIOTester(c)
+    }
+  }
 }

--- a/src/test/scala/verilator/ZeroWidth.scala
+++ b/src/test/scala/verilator/ZeroWidth.scala
@@ -1,0 +1,22 @@
+package verilator
+
+import chisel3._
+import chisel3.iotesters._
+
+class ZeroWidthIOModule extends Module {
+  val io = IO(new Bundle {
+    val zeroIn   = Input(UInt(0.W))
+    val zeroOut  = Output(UInt(0.W))
+
+    val otherIn  = Input(UInt(3.W))
+    val otherOut = Output(UInt(3.W))
+  })
+
+  io.zeroOut  := io.zeroIn
+  io.otherOut := io.otherIn
+}
+
+class ZeroWidthIOTester(c: ZeroWidthIOModule) extends PeekPokeTester(c) {
+  poke(c.io.otherIn, 3)
+  expect(c.io.otherOut, 3)
+}


### PR DESCRIPTION
I had some IOs with 0-width wires that were causing issues with chisel-testers.

Should I add a test too?