### PR TITLE
Update sbt to 0.13.16; add Scala 2.12 support.

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.15
+sbt.version = 0.13.16

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 logLevel := Level.Warn
 
-addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
+addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 


### PR DESCRIPTION
To clean, test, and build Scala 2.11 and Scala 2.12 versions:
  % sbt +clean +test +publishLocal
NOTE: You need to be running Java 8 to build the 2.12 version.