### PR TITLE
Add support for peek and poking memories to the interpreter backend.

### DIFF
--- a/src/main/scala/chisel3/iotesters/FirrtlTerpBackend.scala
+++ b/src/main/scala/chisel3/iotesters/FirrtlTerpBackend.scala
@@ -4,7 +4,7 @@ package chisel3.iotesters
 import chisel3._
 import chisel3.internal.InstanceId
 import firrtl.{FirrtlExecutionFailure, FirrtlExecutionSuccess}
-import firrtl_interpreter.{HasInterpreterSuite, InterpretiveTester}
+import firrtl_interpreter._
 
 private[iotesters] class FirrtlTerpBackend(
     dut: Module,
@@ -23,6 +23,12 @@ private[iotesters] class FirrtlTerpBackend(
         val name = portNames(port)
         interpretiveTester.poke(name, value)
         if (verbose) logger info s"  POKE $name <- ${bigIntToStr(value, base)}"
+
+      case mem: Mem[_] =>
+        val memoryName = mem.pathName.split("""\.""").tail.mkString(".")
+        interpretiveTester.pokeMemory(memoryName, off.getOrElse(0), value)
+        if (verbose) logger info s"  POKE MEMORY $memoryName <- ${bigIntToStr(value, base)}"
+
       case _ =>
     }
   }
@@ -40,6 +46,12 @@ private[iotesters] class FirrtlTerpBackend(
         val result = interpretiveTester.peek(name)
         if (verbose) logger info s"  PEEK $name -> ${bigIntToStr(result, base)}"
         result
+
+      case mem: Mem[_] =>
+        val memoryName = mem.pathName.split("""\.""").tail.mkString(".")
+
+        interpretiveTester.peekMemory(memoryName, off.getOrElse(0))
+
       case _ => BigInt(rnd.nextInt)
     }
   }

--- a/src/test/scala/chisel3/iotesters/MemPokeSpec.scala
+++ b/src/test/scala/chisel3/iotesters/MemPokeSpec.scala
@@ -1,0 +1,38 @@
+// See LICENSE for license details.
+
+package chisel3.iotesters
+
+import chisel3._
+import org.scalacheck.Prop._
+import org.scalatest.prop.Checkers
+
+class InnerMemModule extends Module {
+  val io: Bundle = IO(new Bundle)
+  val nelly = Mem(1024, UInt(32.W))
+}
+
+class OuterMemModule extends Module {
+  val io: Bundle = IO(new Bundle)
+  val billy = Mem(1024, UInt(32.W))
+  val inner = Module(new InnerMemModule)
+}
+
+class MemPokeTester(m: OuterMemModule) extends PeekPokeTester(m) {
+  reset(10)
+  0 until 1024 foreach { i =>
+    pokeAt(m.billy, i, i)
+    pokeAt(m.inner.nelly, value = i + 1, off = i)
+  }
+  step(10)
+  0 until 1024 foreach { i =>
+    expect(peekAt(m.billy, i) == BigInt(i), s"expected $i at $i, but found ${peekAt(m.billy, i)}")
+    expect(peekAt(m.inner.nelly, i) == BigInt(i + 1), s"expected $i at $i, but found ${peekAt(m.billy, i)}")
+  }
+}
+
+class MemPokeSpec extends ChiselFlatSpec with Checkers {
+  behavior of "TestMem"
+
+  it should "return peek values exactly as poked" in
+    check(Driver.execute(Array(), () => new OuterMemModule) { m => new MemPokeTester(m) })
+}

--- a/src/test/scala/chisel3/iotesters/MemPokeSpec.scala
+++ b/src/test/scala/chisel3/iotesters/MemPokeSpec.scala
@@ -3,18 +3,26 @@
 package chisel3.iotesters
 
 import chisel3._
+import chisel3.util.log2Ceil
 import org.scalacheck.Prop._
 import org.scalatest.prop.Checkers
 
 class InnerMemModule extends Module {
-  val io: Bundle = IO(new Bundle)
+  //noinspection TypeAnnotation
+  val io = IO(new Bundle)
   val nelly = Mem(1024, UInt(32.W))
 }
 
 class OuterMemModule extends Module {
-  val io: Bundle = IO(new Bundle)
+  //noinspection TypeAnnotation
+  val io = IO(new Bundle {
+    val readAddress = Input(UInt(log2Ceil(1024).W))
+    val readData    = Output(UInt(32.W))
+  })
   val billy = Mem(1024, UInt(32.W))
   val inner = Module(new InnerMemModule)
+
+  io.readData := billy(io.readAddress)
 }
 
 class MemPokeTester(m: OuterMemModule) extends PeekPokeTester(m) {
@@ -23,15 +31,28 @@ class MemPokeTester(m: OuterMemModule) extends PeekPokeTester(m) {
     pokeAt(m.billy, i, i)
     pokeAt(m.inner.nelly, value = i + 1, off = i)
   }
+
   step(10)
+
+  // This uses direct access reading
   0 until 1024 foreach { i =>
     expect(peekAt(m.billy, i) == BigInt(i), s"expected $i at $i, but found ${peekAt(m.billy, i)}")
     expect(peekAt(m.inner.nelly, i) == BigInt(i + 1), s"expected $i at $i, but found ${peekAt(m.billy, i)}")
   }
+
+  // This shows that the ordinary memory systems sees the values written with pokeAt
+  0 until 1024 foreach { i =>
+    poke(m.io.readAddress, i)
+    step(1)
+
+    expect(peek(m.io.readData) == BigInt(i), s"expected $i at $i, but found ${peek(m.io.readData)}")
+  }
+
+
 }
 
 class MemPokeSpec extends ChiselFlatSpec with Checkers {
-  behavior of "TestMem"
+  behavior of "Peeking and Poking straight into underlying memory, in interpreter"
 
   it should "return peek values exactly as poked" in
     check(Driver.execute(Array(), () => new OuterMemModule) { m => new MemPokeTester(m) })


### PR DESCRIPTION
## This requires prior approval of [/firrtl-interpreter/pull/92](https://github.com/freechipsproject/firrtl-interpreter/pull/92)
Add support for peek and poking memories to the interpreter backend.
Add a test to show that it works
This is an interpreter only fix for [/chisel-testers/issues/166](https://github.com/freechipsproject/chisel-testers/issues/166)