### PR TITLE
Invalidateapifix

### DIFF
--- a/src/main/scala/chisel3/iotesters/Exerciser.scala
+++ b/src/main/scala/chisel3/iotesters/Exerciser.scala
@@ -49,6 +49,7 @@ abstract class Exerciser extends BasicTester {
   }
   def buildState(name: String = s"$current_states")(stop_condition : StopCondition)(generator: () => Unit): Unit = {
     //noinspection ScalaStyle
+    device_under_test.io := DontCare  // Support invalidate API.
     println(s"building state $current_states $name")
     when(state_number === (current_states).asUInt) {
       when(! state_locked) {

--- a/src/main/scala/chisel3/iotesters/SteppedHWIOTester.scala
+++ b/src/main/scala/chisel3/iotesters/SteppedHWIOTester.scala
@@ -128,7 +128,6 @@ abstract class SteppedHWIOTester extends HWIOTester {
       }
     )
     input_port := input_values(counter.value)
-
   }
 
   private def createVectorsAndTestsForOutput(output_port: Data, counter: Counter): Unit = {

--- a/src/main/scala/chisel3/iotesters/SteppedHWIOTester.scala
+++ b/src/main/scala/chisel3/iotesters/SteppedHWIOTester.scala
@@ -128,6 +128,7 @@ abstract class SteppedHWIOTester extends HWIOTester {
       }
     )
     input_port := input_values(counter.value)
+
   }
 
   private def createVectorsAndTestsForOutput(output_port: Data, counter: Counter): Unit = {
@@ -171,6 +172,7 @@ abstract class SteppedHWIOTester extends HWIOTester {
 
   override def finish(): Unit = {
     io_info = new IOAccessor(device_under_test.io)
+    device_under_test.io := DontCare
 
     processEvents()
 

--- a/src/test/scala/verilator/doohickey.scala
+++ b/src/test/scala/verilator/doohickey.scala
@@ -11,4 +11,8 @@ class doohickey() extends Module {
   val bobs = Seq.fill(16) {
     Module(new thingamabob()).io
   }
+  // Support the invalidate API
+  for (bob <- bobs) {
+    bob := DontCare
+  }
 }


### PR DESCRIPTION
firrtl freechipsproject/firrtl#706 changes the way submodule connections are handled, and causes hardware testers to provoke unconnected errors. This pr adds `DontCare`'s to avoid the problem.

This may not be the correct long-term solution.
