### PR TITLE
Fix use of bare Bundle in MemPokeSpec.

### DIFF
--- a/src/test/scala/chisel3/iotesters/MemPokeSpec.scala
+++ b/src/test/scala/chisel3/iotesters/MemPokeSpec.scala
@@ -9,7 +9,9 @@ import org.scalatest.prop.Checkers
 
 class InnerMemModule extends Module {
   //noinspection TypeAnnotation
-  val io = IO(new Bundle)
+  val io = IO(new Bundle {
+    val in = Input(Bool())
+  })
   val nelly = Mem(1024, UInt(32.W))
 }
 
@@ -21,6 +23,7 @@ class OuterMemModule extends Module {
   })
   val billy = Mem(1024, UInt(32.W))
   val inner = Module(new InnerMemModule)
+  inner.io.in := false.B
 
   io.readData := billy(io.readAddress)
 }

--- a/src/test/scala/chisel3/iotesters/MemPokeSpec.scala
+++ b/src/test/scala/chisel3/iotesters/MemPokeSpec.scala
@@ -9,9 +9,7 @@ import org.scalatest.prop.Checkers
 
 class InnerMemModule extends Module {
   //noinspection TypeAnnotation
-  val io = IO(new Bundle {
-    val in = Input(Bool())
-  })
+  val io = IO(new Bundle {})
   val nelly = Mem(1024, UInt(32.W))
 }
 
@@ -23,7 +21,6 @@ class OuterMemModule extends Module {
   })
   val billy = Mem(1024, UInt(32.W))
   val inner = Module(new InnerMemModule)
-  inner.io.in := false.B
 
   io.readData := billy(io.readAddress)
 }


### PR DESCRIPTION
Now that Bundle is an abstract class (freechipsproject/chisel3#774), replace
a bare Bundle with a concrete one.