### PR TITLE
Add iverilog as a backend

### DIFF
--- a/src/main/resources/vpi.h
+++ b/src/main/resources/vpi.h
@@ -231,6 +231,8 @@ private:
         }
       }
 
+// It seems iverilog does not support vpiPrimitive yet
+#ifndef __ICARUS__
       // Find DFF
       vpiHandle udp_iter = vpi_iterate(vpiPrimitive, mod_handle);
       while (vpiHandle udp_handle = vpi_scan(udp_iter)) {
@@ -238,6 +240,7 @@ private:
           add_signal(udp_handle, modname);
         }
       }
+#endif
 
       vpiHandle sub_iter = vpi_iterate(vpiModule, mod_handle);
       while (vpiHandle sub_handle = vpi_scan(sub_iter)) {

--- a/src/main/resources/vpi.h
+++ b/src/main/resources/vpi.h
@@ -206,13 +206,12 @@ private:
       std::string modname = std::string(vpi_get_str(vpiFullName, mod_handle)).substr(offset);
       // Iterate its nets
       vpiHandle net_iter = vpi_iterate(vpiNet, mod_handle);
-      if(net_iter){
+      if(net_iter)
         while (vpiHandle net_handle = vpi_scan(net_iter)) {
           std::string netname = vpi_get_str(vpiName, net_handle);
           std::string netpath = modname + "." + netname;
           add_signal(net_handle, netpath);
         }
-      }
 
       // Iterate its regs
       vpiHandle reg_iter = vpi_iterate(vpiReg, mod_handle);

--- a/src/main/resources/vpi.h
+++ b/src/main/resources/vpi.h
@@ -206,46 +206,53 @@ private:
       std::string modname = std::string(vpi_get_str(vpiFullName, mod_handle)).substr(offset);
       // Iterate its nets
       vpiHandle net_iter = vpi_iterate(vpiNet, mod_handle);
-      while (vpiHandle net_handle = vpi_scan(net_iter)) {
-        std::string netname = vpi_get_str(vpiName, net_handle);
-        std::string netpath = modname + "." + netname;
-        add_signal(net_handle, netpath);
+      if(net_iter){
+        while (vpiHandle net_handle = vpi_scan(net_iter)) {
+          std::string netname = vpi_get_str(vpiName, net_handle);
+          std::string netpath = modname + "." + netname;
+          add_signal(net_handle, netpath);
+        }
       }
 
       // Iterate its regs
       vpiHandle reg_iter = vpi_iterate(vpiReg, mod_handle);
-      while (vpiHandle reg_handle = vpi_scan(reg_iter)) {
-        std::string regname = vpi_get_str(vpiName, reg_handle);
-        std::string regpath = modname + "." + regname;
-        add_signal(reg_handle, regpath);
-      }
+      if(reg_iter)
+        while (vpiHandle reg_handle = vpi_scan(reg_iter)) {
+          std::string regname = vpi_get_str(vpiName, reg_handle);
+          std::string regpath = modname + "." + regname;
+          add_signal(reg_handle, regpath);
+        }
 
       // Iterate its mems
       vpiHandle mem_iter = vpi_iterate(vpiRegArray, mod_handle);
-      while (vpiHandle mem_handle = vpi_scan(mem_iter)) {
-        vpiHandle elm_iter = vpi_iterate(vpiReg, mem_handle);
-        while (vpiHandle elm_handle = vpi_scan(elm_iter)) {
-          std::string elmname = vpi_get_str(vpiName, elm_handle);
-          std::string elmpath = modname + "." + elmname;
-          add_signal(elm_handle, elmpath);
+      if(mem_iter)
+        while (vpiHandle mem_handle = vpi_scan(mem_iter)) {
+          vpiHandle elm_iter = vpi_iterate(vpiReg, mem_handle);
+          if(elm_iter)
+            while (vpiHandle elm_handle = vpi_scan(elm_iter)) {
+              std::string elmname = vpi_get_str(vpiName, elm_handle);
+              std::string elmpath = modname + "." + elmname;
+              add_signal(elm_handle, elmpath);
+            }
         }
-      }
 
 // It seems iverilog does not support vpiPrimitive yet
 #ifndef __ICARUS__
       // Find DFF
       vpiHandle udp_iter = vpi_iterate(vpiPrimitive, mod_handle);
-      while (vpiHandle udp_handle = vpi_scan(udp_iter)) {
-        if (vpi_get(vpiPrimType, udp_handle) == vpiSeqPrim) {
-          add_signal(udp_handle, modname);
+      if(udp_iter)
+        while (vpiHandle udp_handle = vpi_scan(udp_iter)) {
+          if (vpi_get(vpiPrimType, udp_handle) == vpiSeqPrim) {
+            add_signal(udp_handle, modname);
+          }
         }
-      }
 #endif
 
       vpiHandle sub_iter = vpi_iterate(vpiModule, mod_handle);
-      while (vpiHandle sub_handle = vpi_scan(sub_iter)) {
-        modules.push(sub_handle);
-      }
+      if(sub_iter)
+        while (vpiHandle sub_handle = vpi_scan(sub_iter)) {
+          modules.push(sub_handle);
+        }
     }
   }
 };

--- a/src/main/resources/vpi_register.cpp
+++ b/src/main/resources/vpi_register.cpp
@@ -1,0 +1,90 @@
+/*
+ * VPI register
+ * -----------------------------------------------------------------------
+ * Jimmy Situ (web@jimmystone.cn)
+ */
+
+#include <vpi_user.h>
+#include <sv_vpi_user.h>
+
+
+/*
+ * This is a table of register functions. This table is the external
+ * symbol that the simulator looks for when loading this .vpi module.
+ */
+
+extern "C" PLI_INT32 init_rsts_calltf(PLI_BYTE8 *user_data);
+extern "C" PLI_INT32 init_ins_calltf(PLI_BYTE8 *user_data);
+extern "C" PLI_INT32 init_outs_calltf(PLI_BYTE8 *user_data);
+extern "C" PLI_INT32 init_sigs_calltf(PLI_BYTE8 *user_data);
+extern "C" PLI_INT32 tick_calltf(PLI_BYTE8 *user_data);
+extern "C" PLI_INT32 tick_compiletf(PLI_BYTE8 *user_data);
+
+void init_rsts_register(void)
+{
+  s_vpi_systf_data tf_data;
+
+  tf_data.type      = vpiSysTask;
+  tf_data.tfname    = "$init_rsts";
+  tf_data.calltf    = init_rsts_calltf;
+  tf_data.sizetf    = 0;
+  tf_data.compiletf = 0;
+  vpi_register_systf(&tf_data);
+}
+
+void init_ins_register(void)
+{
+  s_vpi_systf_data tf_data;
+
+  tf_data.type      = vpiSysTask;
+  tf_data.tfname    = "$init_ins";
+  tf_data.calltf    = init_ins_calltf;
+  tf_data.sizetf    = 0;
+  tf_data.compiletf = 0;
+  vpi_register_systf(&tf_data);
+}
+
+void init_outs_register(void)
+{
+  s_vpi_systf_data tf_data;
+
+  tf_data.type      = vpiSysTask;
+  tf_data.tfname    = "$init_outs";
+  tf_data.calltf    = init_outs_calltf;
+  tf_data.sizetf    = 0;
+  tf_data.compiletf = 0;
+  vpi_register_systf(&tf_data);
+}
+
+void init_sigs_register(void)
+{
+  s_vpi_systf_data tf_data;
+
+  tf_data.type      = vpiSysTask;
+  tf_data.tfname    = "$init_sigs";
+  tf_data.calltf    = init_sigs_calltf;
+  tf_data.sizetf    = 0;
+  tf_data.compiletf = 0;
+  vpi_register_systf(&tf_data);
+}
+
+void tick_register(void)
+{
+  s_vpi_systf_data tf_data;
+
+  tf_data.type      = vpiSysTask;
+  tf_data.tfname    = "$tick";
+  tf_data.calltf    = tick_calltf;
+  tf_data.sizetf    = 0;
+  tf_data.compiletf = tick_compiletf;
+  vpi_register_systf(&tf_data);
+}
+
+void (*vlog_startup_routines[])(void) = {
+      init_rsts_register,
+      init_ins_register,
+      init_outs_register,
+      init_sigs_register,
+      tick_register,
+      0
+};

--- a/src/main/scala/chisel3/iotesters/ChiselMain.scala
+++ b/src/main/scala/chisel3/iotesters/ChiselMain.scala
@@ -56,6 +56,10 @@ object chiselMain {
         val waveform = new File(dir, s"${chirrtl.main}.vcd").toString
         harness.write(VerilatorCppHarnessGenerator.codeGen(dut, CircuitState(chirrtl, ChirrtlForm), waveform))
         harness.close()
+      case "ivl" =>
+        val harness = new FileWriter(new File(dir, s"${chirrtl.main}-harness.v"))
+        val waveform = new File(dir, s"${chirrtl.main}.vcd").toString
+        genIVLVerilogHarness(dut, harness, waveform.toString)
       case "vcs" | "glsim" =>
         val harness = new FileWriter(new File(dir, s"${chirrtl.main}-harness.v"))
         val waveform = new File(dir, s"${chirrtl.main}.vpd").toString

--- a/src/main/scala/chisel3/iotesters/ChiselPokeSpec.scala
+++ b/src/main/scala/chisel3/iotesters/ChiselPokeSpec.scala
@@ -20,6 +20,11 @@ case object VerilatorBackend extends TesterBackend {
     setupVerilatorBackend(dutGen, options)
   }
 }
+case object IvlBackend extends TesterBackend {
+  override def create[T <: Module](dutGen: () => T, options: TesterOptionsManager): (T, Backend) = {
+    setupIVLBackend(dutGen, options)
+  }
+}
 case object VcsBackend extends TesterBackend {
   override def create[T <: Module](dutGen: () => T, options: TesterOptionsManager): (T, Backend) = {
     setupVCSBackend(dutGen, options)

--- a/src/main/scala/chisel3/iotesters/CommandEditor.scala
+++ b/src/main/scala/chisel3/iotesters/CommandEditor.scala
@@ -8,7 +8,7 @@ import scala.io.Source
 import scala.util.matching.Regex
 
 /**
-  * This function applies a last chance method of making final alteration of the vcs command line.
+  * This function applies a last chance method of making final alteration of the ivl/vcs command line.
   * Alterations are made from a text file containing ed style regex substitutions
   * s/regex-pattern/substitution/ or more generally
   * s<<separator>>regex-pattern<<separator>>substitution<<separator>>
@@ -49,7 +49,7 @@ class CommandEditor(val editCommands: Seq[String], messagePrefix: String) {
           verbose = true
           show(s"""$messagePrefix applying edits to "$currentCommandLine" """)
         case _ =>
-          show(s"""vcs-command-edit ignoring edit command "$line" """)
+          show(s"""ivl/vcs-command-edit ignoring edit command "$line" """)
       }
     }
     currentCommandLine
@@ -65,6 +65,16 @@ object CommandEditor {
     val editCommands = fileOrEditor match {
       case "" =>
         Seq.empty
+      case TesterOptions.IvlFileCommands(fileName) =>
+        val file = new java.io.File(fileName)
+        if (!file.exists()) {
+          val currDir = new File(".").getAbsolutePath
+          println(s"""$DefaultPrefix can't find specified file $fileName, cur dir is $currDir""")
+          Seq.empty
+        }
+        else {
+          Source.fromFile(file).getLines.toSeq
+        }
       case TesterOptions.VcsFileCommands(fileName) =>
         val file = new java.io.File(fileName)
         if (!file.exists()) {

--- a/src/main/scala/chisel3/iotesters/Driver.scala
+++ b/src/main/scala/chisel3/iotesters/Driver.scala
@@ -52,6 +52,8 @@ object Driver {
             setupFirrtlTerpBackend(dutGenerator, optionsManager)
           case "verilator" =>
             setupVerilatorBackend(dutGenerator, optionsManager)
+          case "ivl" =>
+            setupIVLBackend(dutGenerator, optionsManager)
           case "vcs" =>
             setupVCSBackend(dutGenerator, optionsManager)
           case _ =>
@@ -65,6 +67,7 @@ object Driver {
             case e: Throwable =>
               e.printStackTrace()
               backend match {
+                case b: IVLBackend => TesterProcess.kill(b)
                 case b: VCSBackend => TesterProcess.kill(b)
                 case b: VerilatorBackend => TesterProcess.kill(b)
                 case _ =>
@@ -208,6 +211,7 @@ object Driver {
     * @param dutGen      This is the device under test.
     * @param backendType The default backend is "firrtl" which uses the firrtl interperter. Other options
     *                    "verilator" will use the verilator c++ simulation generator
+    *                    "ivl" will use the Icarus Verilog simulation
     *                    "vcs" will use the VCS simulation
     * @param verbose     Setting this to true will make the tester display information on peeks,
     *                    pokes, steps, and expects.  By default only failed expects will be printed
@@ -243,6 +247,8 @@ object Driver {
       } catch { case e: Throwable =>
         e.printStackTrace()
         backend match {
+          case Some(b: IVLBackend) =>
+            TesterProcess kill b
           case Some(b: VCSBackend) =>
             TesterProcess kill b
           case Some(b: VerilatorBackend) =>

--- a/src/main/scala/chisel3/iotesters/IVLBackend.scala
+++ b/src/main/scala/chisel3/iotesters/IVLBackend.scala
@@ -1,0 +1,188 @@
+// See LICENSE for license details.
+package chisel3.iotesters
+
+import java.io.{File, FileWriter, IOException, Writer}
+import java.nio.file.{FileAlreadyExistsException, Files, Paths}
+import java.nio.file.StandardCopyOption.REPLACE_EXISTING
+
+import chisel3.{ChiselExecutionFailure, ChiselExecutionSuccess, Element}
+import chisel3.experimental.MultiIOModule
+import firrtl.{ChirrtlForm, CircuitState}
+import firrtl.transforms.BlackBoxTargetDirAnno
+
+/**
+  * Copies the necessary header files used for iverilog compilation to the specified destination folder
+  */
+object copyIvlFiles {
+  def apply(destinationDirPath: String): Unit = {
+    new File(destinationDirPath).mkdirs()
+    val simApiHFilePath = Paths.get(destinationDirPath + "/sim_api.h")
+    val vpiHFilePath = Paths.get(destinationDirPath + "/vpi.h")
+    val vpiCppFilePath = Paths.get(destinationDirPath + "/vpi.cpp")
+    val vpiRegFilePath = Paths.get(destinationDirPath + "/vpi_register.cpp")
+    try {
+      Files.createFile(simApiHFilePath)
+      Files.createFile(vpiHFilePath)
+      Files.createFile(vpiCppFilePath)
+      Files.createFile(vpiRegFilePath)
+    } catch {
+      case _: FileAlreadyExistsException =>
+        System.out.format("")
+      case x: IOException =>
+        System.err.format("createFile error: %s%n", x)
+    }
+
+    Files.copy(getClass.getResourceAsStream("/sim_api.h"), simApiHFilePath, REPLACE_EXISTING)
+    Files.copy(getClass.getResourceAsStream("/vpi.h"), vpiHFilePath, REPLACE_EXISTING)
+    Files.copy(getClass.getResourceAsStream("/vpi.cpp"), vpiCppFilePath, REPLACE_EXISTING)
+    Files.copy(getClass.getResourceAsStream("/vpi_register.cpp"), vpiRegFilePath, REPLACE_EXISTING)
+  }
+}
+
+/**
+  * Generates the Module specific verilator harness cpp file for verilator compilation
+  */
+object genIVLVerilogHarness {
+  def apply(dut: MultiIOModule, writer: Writer, vpdFilePath: String, isGateLevel: Boolean = false) {
+    val dutName = dut.name
+    // getPorts() is going to return names prefixed with the dut name.
+    // These don't correspond to code currently generated for verilog modules,
+    //  so we have to strip the dut name prefix (and the delimiter) from the name.
+    // We tell getPorts() to use "_" as the delimiter to simplify the replacement regexp.
+    def fixnames(portSeq: (Seq[(Element, String)], Seq[(Element, String)])): (Seq[(Element, String)], Seq[(Element, String)]) = {
+      val replaceRegexp = ("^" + dutName + "_").r
+      (
+        portSeq._1 map { case (e: Element, s: String) => (e, replaceRegexp.replaceFirstIn(s, ""))},
+        portSeq._2 map { case (e: Element, s: String) => (e, replaceRegexp.replaceFirstIn(s, ""))}
+      )
+    }
+    val (inputs, outputs) = fixnames(getPorts(dut, "_"))
+
+    writer write "module test;\n"
+    writer write "  reg clock = 1;\n"
+    writer write "  reg reset = 1;\n"
+    val delay = if (isGateLevel) "#0.1" else ""
+    inputs foreach { case (node, name) =>
+      if ("clock" != name && "reset" != name) {
+        writer write s"  reg[${node.getWidth-1}:0] $name = 0;\n"
+        writer write s"  wire[${node.getWidth-1}:0] ${name}_delay;\n"
+        writer write s"  assign $delay ${name}_delay = $name;\n"
+      }
+    }
+    outputs foreach { case (node, name) =>
+      writer write s"  wire[${node.getWidth-1}:0] ${name}_delay;\n"
+      writer write s"  wire[${node.getWidth-1}:0] $name;\n"
+      writer write s"  assign $delay $name = ${name}_delay;\n"
+    }
+
+    writer write "  always #`CLOCK_PERIOD clock = ~clock;\n"
+    writer write "  reg vcdon = 0;\n"
+    writer write "  reg [1023:0] vcdfile = 0;\n"
+    writer write "  reg [1023:0] vpdfile = 0;\n"
+
+    writer write "\n  /*** DUT instantiation ***/\n"
+    writer write s"  $dutName $dutName(\n"
+    writer write "    .clock(clock),\n"
+    writer write "    .reset(reset),\n"
+    writer write (((inputs ++ outputs).unzip._2 map (name =>
+        if ("clock" != name && "reset" != name) s"    .$name(${name}_delay)" else None)).filter(_ != None) mkString ",\n"
+      )
+    writer write "  );\n\n"
+
+    writer write "  initial begin\n"
+    writer write "    $init_rsts(reset);\n"
+    writer write "    $init_ins(%s);\n".format(inputs.unzip._2 mkString ", ")
+    writer write "    $init_outs(%s);\n".format(outputs.unzip._2 mkString ", ")
+    writer write "    $init_sigs(%s);\n".format(dutName)
+    writer write "    /*** VCD dump ***/\n"
+    writer write "    if ($value$plusargs(\"vcdfile=%s\", vcdfile)) begin\n"
+    writer write "      $dumpfile(vcdfile);\n"
+    writer write "      $dumpvars(0, %s);\n".format(dutName)
+    writer write "      $dumpoff;\n"
+    writer write "      vcdon = 0;\n"
+    writer write "    end\n"
+    writer write "  end\n\n"
+
+    writer write "  always @(%s clock) begin\n".format(if (isGateLevel) "posedge" else "negedge")
+    writer write "    if (vcdfile && reset) begin\n"
+    writer write "      $dumpoff;\n"
+    writer write "      vcdon = 0;\n"
+    writer write "    end\n"
+    writer write "    else if (vcdfile && !vcdon) begin\n"
+    writer write "      $dumpon;\n"
+    writer write "      vcdon = 1;\n"
+    writer write "    end\n"
+    writer write "    %s $tick();\n".format(if (isGateLevel) "#0.05" else "")
+    writer write "  end\n\n"
+    writer write "endmodule\n"
+    writer.close()
+  }
+}
+
+private[iotesters] object setupIVLBackend {
+  def apply[T <: MultiIOModule](dutGen: () => T, optionsManager: TesterOptionsManager): (T, Backend) = {
+    optionsManager.makeTargetDir()
+    optionsManager.chiselOptions = optionsManager.chiselOptions.copy(
+      runFirrtlCompiler = false
+    )
+    val dir = new File(optionsManager.targetDirName)
+
+    // Generate CHIRRTL
+    chisel3.Driver.execute(optionsManager, dutGen) match {
+      case ChiselExecutionSuccess(Some(circuit), emitted, _) =>
+
+        val chirrtl = firrtl.Parser.parse(emitted)
+        val dut = getTopModule(circuit).asInstanceOf[T]
+
+        /*
+        The following block adds an annotation that tells the black box helper where the
+        current build directory is, so that it can copy verilog resource files into the right place
+         */
+        val annotations = optionsManager.firrtlOptions.annotations ++
+          List(BlackBoxTargetDirAnno(optionsManager.targetDirName))
+
+        val transforms = optionsManager.firrtlOptions.customTransforms
+
+        // Generate Verilog
+        val verilogFile = new File(dir, s"${circuit.name}.v")
+        val verilogWriter = new FileWriter(verilogFile)
+
+        val compileResult = (new firrtl.VerilogCompiler).compileAndEmit(
+          CircuitState(chirrtl, ChirrtlForm, annotations),
+          customTransforms = transforms
+        )
+        val compiledStuff = compileResult.getEmittedCircuit
+        verilogWriter.write(compiledStuff.value)
+        verilogWriter.close()
+
+        // Generate Harness
+        val ivlHarnessFileName = s"${circuit.name}-harness.v"
+        val ivlHarnessFile = new File(dir, ivlHarnessFileName)
+        val vcdFile = new File(dir, s"${circuit.name}.vcd")
+        copyIvlFiles(dir.toString)
+        genIVLVerilogHarness(dut, new FileWriter(ivlHarnessFile), vcdFile.toString)
+        assert(
+          verilogToIVL(circuit.name, dir, new File(ivlHarnessFileName),
+            moreIvlFlags = optionsManager.testerOptions.moreIvlFlags,
+            moreIvlCFlags = optionsManager.testerOptions.moreIvlCFlags,
+            editCommands = optionsManager.testerOptions.ivlCommandEdits
+          ).! == 0)
+
+        val command = if(optionsManager.testerOptions.testCmd.nonEmpty) {
+          optionsManager.testerOptions.testCmd
+        }
+        else {
+          Seq(new File(dir, circuit.name).toString)
+        }
+
+        (dut, new IVLBackend(dut, command))
+      case ChiselExecutionFailure(message) =>
+        throw new Exception(message)
+    }
+  }
+}
+
+private[iotesters] class IVLBackend(dut: MultiIOModule,
+                                    cmd: Seq[String],
+                                    _seed: Long = System.currentTimeMillis)
+           extends VerilatorBackend(dut, cmd, _seed)

--- a/src/main/scala/chisel3/iotesters/PeekPokeTesterUtils.scala
+++ b/src/main/scala/chisel3/iotesters/PeekPokeTesterUtils.scala
@@ -225,6 +225,9 @@ private[iotesters] object TesterProcess {
     while(!sim.exitValue.isCompleted) sim.process.destroy
     println("Exit Code: %d".format(sim.process.exitValue))
   }
+  def kill(p: IVLBackend) {
+    kill(p.simApiInterface)
+  }
   def kill(p: VCSBackend) {
     kill(p.simApiInterface)
   }

--- a/src/main/scala/chisel3/iotesters/PeekPokeTesterUtils.scala
+++ b/src/main/scala/chisel3/iotesters/PeekPokeTesterUtils.scala
@@ -86,6 +86,69 @@ private[iotesters] object bigIntToStr {
   }
 }
 
+private[iotesters] object verilogToIVL {
+  def constructIvlFlags(
+      topModule: String,
+      dir: java.io.File,
+      moreIvlFlags: Seq[String] = Seq.empty[String]): Seq[String] = {
+
+    val blackBoxVerilogList = {
+      val list_file = new File(dir, firrtl.transforms.BlackBoxSourceHelper.FileListName)
+      if(list_file.exists()) {
+        Seq("-f", list_file.getAbsolutePath)
+      }
+      else {
+        Seq.empty[String]
+      }
+    }
+
+    val ivlFlags = Seq(
+      "-m ./%s/%s.vpi".format(dir.toString, topModule),
+      "-g2005-sv",
+      "-DCLOCK_PERIOD=1") ++
+      moreIvlFlags ++
+      blackBoxVerilogList
+
+    ivlFlags
+  }
+
+  def constructIvlCFlags(
+      topModule: String,
+      dir: java.io.File,
+      moreIvlCFlags: Seq[String] = Seq.empty[String]): Seq[String] = {
+
+    val DefaultCcFlags = Seq("-I$IVL_HOME", s"-I$dir", "-fPIC", "-std=c++11", "-lvpi", "-lveriuser", "-shared")
+
+    val ivlCFlags = Seq(
+      s"-o $topModule.vpi", "-D__ICARUS__") ++ 
+      DefaultCcFlags ++ moreIvlCFlags
+
+    ivlCFlags
+  }
+
+  def apply(
+    topModule: String,
+    dir: java.io.File,
+    ivlHarness: java.io.File,
+    moreIvlFlags: Seq[String] = Seq.empty[String],
+    moreIvlCFlags: Seq[String] = Seq.empty[String],
+    editCommands: String = ""): ProcessBuilder = {
+
+    val ivlFlags = constructIvlFlags(topModule, dir, moreIvlFlags)
+    val ivlCFlags = constructIvlCFlags(topModule, dir, moreIvlCFlags)
+
+    val cmd = Seq("cd", dir.toString, "&&") ++
+                Seq("g++") ++ ivlCFlags ++ Seq("vpi.cpp", "vpi_register.cpp", "&&") ++
+                Seq("iverilog") ++ ivlFlags ++ Seq("-o", topModule, s"$topModule.v", ivlHarness.toString) mkString " "
+
+    val commandEditor = CommandEditor(editCommands, "ivl-command-edit")
+    val finalCommand = commandEditor(cmd)
+    println(s"$finalCommand")
+
+    Seq("bash", "-c", finalCommand)
+  }
+}
+
 private[iotesters] object verilogToVCS {
   def constructVcsFlags(
       topModule: String,
@@ -146,7 +209,7 @@ private[iotesters] object verilogToVCS {
 }
 
 private[iotesters] case class BackendException(b: String)
-  extends Exception(s"Unknown backend: $b. Backend should be firrtl, verilator, vcs, or glsim")
+  extends Exception(s"Unknown backend: $b. Backend should be firrtl, verilator, ivl, vcs, or glsim")
 
 private[iotesters] case class TestApplicationException(exitVal: Int, lastMessage: String)
   extends RuntimeException(lastMessage)

--- a/src/main/scala/chisel3/iotesters/TesterOptions.scala
+++ b/src/main/scala/chisel3/iotesters/TesterOptions.scala
@@ -22,12 +22,12 @@ case class TesterOptions(
                           moreVcsFlags:    Seq[String] = Seq.empty,
                           moreVcsCFlags:   Seq[String] = Seq.empty,
                           vcsCommandEdits: String = "",
-                          moreIvlFlags:    Seq[String] = Seq.empty,
-                          moreIvlCFlags:   Seq[String] = Seq.empty,
-                          ivlCommandEdits: String = "",
                           backendName:     String  = "firrtl",
                           logFileName:     String  = "",
-                          waveform:        Option[File] = None) extends ComposableOptions
+                          waveform:        Option[File] = None,
+                          moreIvlFlags:    Seq[String] = Seq.empty,
+                          moreIvlCFlags:   Seq[String] = Seq.empty,
+                          ivlCommandEdits: String = "") extends ComposableOptions
 
 object TesterOptions {
   val VcsFileCommands: Regex = """file:(.+)""".r

--- a/src/main/scala/chisel3/iotesters/TesterOptions.scala
+++ b/src/main/scala/chisel3/iotesters/TesterOptions.scala
@@ -22,12 +22,16 @@ case class TesterOptions(
                           moreVcsFlags:    Seq[String] = Seq.empty,
                           moreVcsCFlags:   Seq[String] = Seq.empty,
                           vcsCommandEdits: String = "",
+                          moreIvlFlags:    Seq[String] = Seq.empty,
+                          moreIvlCFlags:   Seq[String] = Seq.empty,
+                          ivlCommandEdits: String = "",
                           backendName:     String  = "firrtl",
                           logFileName:     String  = "",
                           waveform:        Option[File] = None) extends ComposableOptions
 
 object TesterOptions {
   val VcsFileCommands: Regex = """file:(.+)""".r
+  val IvlFileCommands: Regex = """file:(.+)""".r
 }
 
 trait HasTesterOptions {
@@ -37,10 +41,10 @@ trait HasTesterOptions {
 
   parser.note("tester options")
 
-  parser.opt[String]("backend-name").valueName("<firrtl|verilator|vcs>")
+  parser.opt[String]("backend-name").valueName("<firrtl|verilator|ivl|vcs>")
     .abbr("tbn")
     .validate { x =>
-      if (Array("firrtl", "verilator", "vcs").contains(x.toLowerCase)) parser.success
+      if (Array("firrtl", "verilator", "ivl", "vcs").contains(x.toLowerCase)) parser.success
       else parser.failure(s"$x not a legal backend name")
     }
     .foreach { x => testerOptions = testerOptions.copy(backendName = x) }
@@ -90,6 +94,22 @@ trait HasTesterOptions {
     .abbr("tvce")
     .foreach { x =>
       testerOptions = testerOptions.copy(vcsCommandEdits = x) }
+    .text("a file containing regex substitutions, one per line s/pattern/replacement/")
+
+  parser.opt[String]("more-ivl-flags")
+    .abbr("tmif")
+    .foreach { x => testerOptions = testerOptions.copy(moreIvlFlags = x.split("""\s""")) }
+    .text("Add specified commands to the ivl command line")
+
+  parser.opt[String]("more-ivl-c-flags")
+    .abbr("tmicf")
+    .foreach { x => testerOptions = testerOptions.copy(moreIvlCFlags = x.split("""\s""")) }
+    .text("Add specified commands to the CFLAGS on the ivl command line")
+
+  parser.opt[String]("ivl-command-edits")
+    .abbr("tice")
+    .foreach { x =>
+      testerOptions = testerOptions.copy(ivlCommandEdits = x) }
     .text("a file containing regex substitutions, one per line s/pattern/replacement/")
 
   parser.opt[String]("log-file-name")


### PR DESCRIPTION
Add Icarus Verilog, a free open source verilog simulator as backend
### Pros
- Iverilog is really usefully when you want to simulate you design which includes one or more blackbox.
And only verilog model is available for the blackbox.
- It save your VCS licences at the same time.
### Cons
- Iverilog is much slower the VCS and verilator, especially for large design. But it is fast enough for small module level verification

### Usage
Need to install iverilog, and setting $IVL_HOME, usually
```bash
export IVL_HOME=/usr/include/iverilog
```
or
```bash
export IVL_HOME=/usr/local/include/iverilog
```
