### PR TITLE
Enable VCS blackbox test.

### DIFF
--- a/src/test/scala/chisel3/iotesters/BlackBoxVerilogDeliverySpec.scala
+++ b/src/test/scala/chisel3/iotesters/BlackBoxVerilogDeliverySpec.scala
@@ -76,17 +76,15 @@ class BlackBoxVerilogDeliverySpec extends FreeSpec with Matchers {
     } should be (true)
   }
 
-  //TODO: The following fails or succeeds depending on vcs in users path, figure out how to test
-//  "blackbox verilog implementation should end up accessible to vcs" in {
-//    val manager = new TesterOptionsManager {
-//      testerOptions = testerOptions.copy(backendName = "vcs")
-//    }
-//    intercept[AssertionError] {
-//      iotesters.Driver.execute(() => new UsesBBAddOne, manager) { c =>
-//        new UsesBBAddOneTester(c)
-//      } should be(true)
-//    }
-//    new java.io.File(
-//        manager.targetDirName, firrtl.transforms.BlackBoxSourceHelper.FileListName).exists() should be (true)
-//  }
+  "blackbox verilog implementation should end up accessible to vcs" in {
+    assume(firrtl.FileUtils.isVCSAvailable)
+    val manager = new TesterOptionsManager {
+      testerOptions = testerOptions.copy(backendName = "vcs")
+    }
+    iotesters.Driver.execute(() => new UsesBBAddOne, manager) { c =>
+      new UsesBBAddOneTester(c)
+    } should be(true)
+    new java.io.File(
+        manager.targetDirName, firrtl.transforms.BlackBoxSourceHelper.fileListName).exists() should be (true)
+  }
 }


### PR DESCRIPTION
Add the assumption that VCS is available.
Remove the expected AssertionError - I'm unsure why we would expect the VCS implementation to fail.