### PR TITLE
Add treadle support.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -47,10 +47,11 @@ crossScalaVersions := Seq("2.11.12", "2.12.4")
 val defaultVersions = Map(
   "chisel3" -> "3.2-SNAPSHOT",
   "firrtl" -> "1.2-SNAPSHOT",
-  "firrtl-interpreter" -> "1.2-SNAPSHOT"
+  "firrtl-interpreter" -> "1.2-SNAPSHOT",
+  "treadle" -> "1.1-SNAPSHOT"
   )
 
-libraryDependencies ++= Seq("chisel3","firrtl","firrtl-interpreter").map { dep: String =>
+libraryDependencies ++= Seq("chisel3","firrtl","firrtl-interpreter", "treadle").map { dep: String =>
     "edu.berkeley.cs" %% dep % sys.props.getOrElse(dep + "Version", defaultVersions(dep))
 }
 

--- a/build.sc
+++ b/build.sc
@@ -73,7 +73,8 @@ object chiselTesters extends Cross[ChiselTestersModule](crossVersions: _*) {
 val defaultVersions = Map(
   "chisel3" -> "3.2-SNAPSHOT",
   "firrtl" -> "1.2-SNAPSHOT",
-  "firrtl-interpreter" -> "1.2-SNAPSHOT"
+  "firrtl-interpreter" -> "1.2-SNAPSHOT",
+  "treadle" -> "1.1-SNAPSHOT"
   )
 
 def getVersion(dep: String, org: String = "edu.berkeley.cs") = {
@@ -84,7 +85,7 @@ def getVersion(dep: String, org: String = "edu.berkeley.cs") = {
 class ChiselTestersModule(val crossScalaVersion: String) extends CommonModule {
   override def artifactName = "chisel-testers"
 
-  def chiselDeps = Agg("firrtl", "firrtl-interpreter", "chisel3").map { d => getVersion(d) }
+  def chiselDeps = Agg("firrtl", "firrtl-interpreter", "treadle", "chisel3").map { d => getVersion(d) }
 
   override def ivyDeps = Agg(
     ivy"com.github.scopt::scopt:3.6.0"

--- a/src/main/scala/chisel3/iotesters/Driver.scala
+++ b/src/main/scala/chisel3/iotesters/Driver.scala
@@ -50,6 +50,8 @@ object Driver {
         val (dut, backend) = testerOptions.backendName match {
           case "firrtl" =>
             setupFirrtlTerpBackend(dutGenerator, optionsManager)
+          case "treadle" =>
+            setupTreadleBackend(dutGenerator, optionsManager)
           case "verilator" =>
             setupVerilatorBackend(dutGenerator, optionsManager)
           case "ivl" =>

--- a/src/main/scala/chisel3/iotesters/TesterOptions.scala
+++ b/src/main/scala/chisel3/iotesters/TesterOptions.scala
@@ -7,6 +7,7 @@ import java.io.File
 import chisel3.HasChiselExecutionOptions
 import firrtl.{ComposableOptions, ExecutionOptionsManager, HasFirrtlOptions}
 import firrtl_interpreter.HasInterpreterSuite
+import treadle.HasTreadleSuite
 
 import scala.util.matching.Regex
 
@@ -22,7 +23,7 @@ case class TesterOptions(
                           moreVcsFlags:    Seq[String] = Seq.empty,
                           moreVcsCFlags:   Seq[String] = Seq.empty,
                           vcsCommandEdits: String = "",
-                          backendName:     String  = "firrtl",
+                          backendName:     String  = "treadle",
                           logFileName:     String  = "",
                           waveform:        Option[File] = None,
                           moreIvlFlags:    Seq[String] = Seq.empty,
@@ -41,10 +42,10 @@ trait HasTesterOptions {
 
   parser.note("tester options")
 
-  parser.opt[String]("backend-name").valueName("<firrtl|verilator|ivl|vcs>")
+  parser.opt[String]("backend-name").valueName("<firrtl|treadle|verilator|ivl|vcs>")
     .abbr("tbn")
     .validate { x =>
-      if (Array("firrtl", "verilator", "ivl", "vcs").contains(x.toLowerCase)) parser.success
+      if (Array("firrtl", "treadle", "verilator", "ivl", "vcs").contains(x.toLowerCase)) parser.success
       else parser.failure(s"$x not a legal backend name")
     }
     .foreach { x => testerOptions = testerOptions.copy(backendName = x) }
@@ -133,6 +134,7 @@ class TesterOptionsManager
     with HasTesterOptions
     with HasInterpreterSuite
     with HasChiselExecutionOptions
-    with HasFirrtlOptions{
+    with HasFirrtlOptions
+    with HasTreadleSuite {
 }
 

--- a/src/main/scala/chisel3/iotesters/TreadleBackend.scala
+++ b/src/main/scala/chisel3/iotesters/TreadleBackend.scala
@@ -1,0 +1,147 @@
+// See LICENSE for license details.
+
+package chisel3.iotesters
+
+import chisel3.{Bits, ChiselExecutionSuccess, Mem, assert}
+import chisel3.experimental.MultiIOModule
+import chisel3.internal.InstanceId
+import firrtl.{FirrtlExecutionFailure, FirrtlExecutionSuccess}
+import treadle.TreadleTester
+
+private[iotesters] class TreadleBackend(
+  dut: MultiIOModule,
+  firrtlIR: String,
+  optionsManager: TesterOptionsManager = new TesterOptionsManager
+)
+extends Backend(_seed = System.currentTimeMillis()) {
+
+  val treadleTester = new TreadleTester(firrtlIR, optionsManager)
+  reset(5) // reset firrtl treadle on construction
+
+  private val portNames = dut.getPorts.flatMap { case chisel3.internal.firrtl.Port(id, dir) =>
+    val pathName = id.pathName
+    getDataNames(pathName.drop(pathName.indexOf('.') + 1), id)
+  }.toMap
+
+  def poke(signal: InstanceId, value: BigInt, off: Option[Int])
+    (implicit logger: TestErrorLog, verbose: Boolean, base: Int): Unit = {
+    signal match {
+      case port: Bits =>
+        val name = portNames(port)
+        treadleTester.poke(name, value)
+        if (verbose) logger info s"  POKE $name <- ${bigIntToStr(value, base)}"
+
+      case mem: Mem[_] =>
+        val memoryName = mem.pathName.split("""\.""").tail.mkString(".")
+        treadleTester.pokeMemory(memoryName, off.getOrElse(0), value)
+        if (verbose) logger info s"  POKE MEMORY $memoryName <- ${bigIntToStr(value, base)}"
+
+      case _ =>
+    }
+  }
+
+  def poke(signal: InstanceId, value: Int, off: Option[Int])
+    (implicit logger: TestErrorLog, verbose: Boolean, base: Int): Unit = {
+    poke(signal, BigInt(value), off)
+  }
+
+  def peek(signal: InstanceId, off: Option[Int])
+    (implicit logger: TestErrorLog, verbose: Boolean, base: Int): BigInt = {
+    signal match {
+      case port: Bits =>
+        val name = portNames(port)
+        val result = treadleTester.peek(name)
+        if (verbose) logger info s"  PEEK $name -> ${bigIntToStr(result, base)}"
+        result
+
+      case mem: Mem[_] =>
+        val memoryName = mem.pathName.split("""\.""").tail.mkString(".")
+
+        treadleTester.peekMemory(memoryName, off.getOrElse(0))
+
+      case _ => BigInt(rnd.nextInt)
+    }
+  }
+
+  def expect(signal: InstanceId, expected: BigInt, msg: => String)
+    (implicit logger: TestErrorLog, verbose: Boolean, base: Int) : Boolean = {
+    signal match {
+      case port: Bits =>
+        val name = portNames(port)
+        val got = treadleTester.peek(name)
+        val good = got == expected
+        if (verbose || !good) logger info
+          s"""EXPECT AT $stepNumber $msg  $name got ${bigIntToStr(got, base)} expected ${bigIntToStr(expected, base)}""" +
+            s""" ${if (good) "PASS" else "FAIL"}"""
+        if(good) treadleTester.expectationsMet += 1
+        good
+      case _ => false
+    }
+  }
+
+  def expect(signal: InstanceId, expected: Int, msg: => String)
+    (implicit logger: TestErrorLog, verbose: Boolean, base: Int) : Boolean = {
+    expect(signal,BigInt(expected), msg)
+  }
+
+  def poke(path: String, value: BigInt)
+    (implicit logger: TestErrorLog, verbose: Boolean, base: Int): Unit = {
+    assert(false)
+  }
+
+  def peek(path: String)
+    (implicit logger: TestErrorLog, verbose: Boolean, base: Int): BigInt = {
+    assert(false)
+    BigInt(rnd.nextInt)
+  }
+
+  def expect(path: String, expected: BigInt, msg: => String)
+    (implicit logger: TestErrorLog, verbose: Boolean, base: Int) : Boolean = {
+    assert(false)
+    false
+  }
+
+  private var stepNumber: Long = 0L
+
+  def step(n: Int)(implicit logger: TestErrorLog): Unit = {
+    stepNumber += n
+    treadleTester.step(n)
+  }
+
+  def reset(n: Int = 1): Unit = {
+    treadleTester.poke("reset", 1)
+    treadleTester.step(n)
+    treadleTester.poke("reset", 0)
+  }
+
+  def finish(implicit logger: TestErrorLog): Unit = {
+    treadleTester.report()
+  }
+}
+
+private[iotesters] object setupTreadleBackend {
+  def apply[T <: MultiIOModule](
+    dutGen: () => T,
+    optionsManager: TesterOptionsManager = new TesterOptionsManager): (T, Backend) = {
+
+    // the backend must be treadle if we are here, therefore we want the firrtl compiler
+    optionsManager.firrtlOptions = optionsManager.firrtlOptions.copy(compilerName = "low")
+    // Workaround to propagate Annotations generated from command-line options to second Firrtl
+    // invocation, run after updating compilerName so we only get one emitCircuit annotation
+    val annos = firrtl.Driver.getAnnotations(optionsManager)
+    optionsManager.firrtlOptions = optionsManager.firrtlOptions.copy(annotations = annos.toList)
+    chisel3.Driver.execute(optionsManager, dutGen) match {
+      case ChiselExecutionSuccess(Some(circuit), _, Some(firrtlExecutionResult)) =>
+        val dut = getTopModule(circuit).asInstanceOf[T]
+        firrtlExecutionResult match {
+          case FirrtlExecutionSuccess(_, compiledFirrtl) =>
+            (dut, new TreadleBackend(dut, compiledFirrtl, optionsManager = optionsManager))
+          case FirrtlExecutionFailure(message) =>
+            throw new Exception(s"FirrtlBackend: failed firrlt compile message: $message")
+        }
+      case _ =>
+        throw new Exception("Problem with compilation")
+    }
+  }
+}
+


### PR DESCRIPTION
- Create a treadle backend and setup modeled on interpreter
- Make treadle default backend, although most tests explicitly declare a backend
- Add treadle to legal backends list
- Fix up MemoryPoke tests (was getting messed up by DCE)
- Fix up black box tests, treadle has separate black box API now
- Add treadle to sbt dependencies
- Add treadle to mill dependencies