### PR TITLE
Add flag to stop verilator simulation from writing a VCD

### DIFF
--- a/src/main/scala/chisel3/iotesters/FirrtlTerpBackend.scala
+++ b/src/main/scala/chisel3/iotesters/FirrtlTerpBackend.scala
@@ -125,6 +125,12 @@ private[iotesters] object setupFirrtlTerpBackend {
     optionsManager.firrtlOptions = optionsManager.firrtlOptions.copy(compilerName = "low")
     // Workaround to propagate Annotations generated from command-line options to second Firrtl
     // invocation, run after updating compilerName so we only get one emitCircuit annotation
+
+    // generate VcdOutput overrides setting of writeVcd
+    if(optionsManager.testerOptions.generateVcdOutput == "on") {
+      optionsManager.interpreterOptions = optionsManager.interpreterOptions.copy(writeVCD = true)
+    }
+
     val annos = firrtl.Driver.getAnnotations(optionsManager)
     optionsManager.firrtlOptions = optionsManager.firrtlOptions.copy(annotations = annos.toList)
     chisel3.Driver.execute(optionsManager, dutGen) match {

--- a/src/main/scala/chisel3/iotesters/TesterOptions.scala
+++ b/src/main/scala/chisel3/iotesters/TesterOptions.scala
@@ -12,23 +12,25 @@ import treadle.HasTreadleSuite
 import scala.util.matching.Regex
 
 case class TesterOptions(
-                          isGenVerilog:    Boolean = false,
-                          isGenHarness:    Boolean = false,
-                          isCompiling:     Boolean = false,
-                          isRunTest:       Boolean = false,
-                          isVerbose:       Boolean = false,
-                          displayBase:     Int     = 10,
-                          testerSeed:      Long    = System.currentTimeMillis,
-                          testCmd:         Seq[String] = Seq.empty,
-                          moreVcsFlags:    Seq[String] = Seq.empty,
-                          moreVcsCFlags:   Seq[String] = Seq.empty,
-                          vcsCommandEdits: String = "",
-                          backendName:     String  = "treadle",
-                          logFileName:     String  = "",
-                          waveform:        Option[File] = None,
-                          moreIvlFlags:    Seq[String] = Seq.empty,
-                          moreIvlCFlags:   Seq[String] = Seq.empty,
-                          ivlCommandEdits: String = "") extends ComposableOptions
+  isGenVerilog:         Boolean = false,
+  isGenHarness:         Boolean = false,
+  isCompiling:          Boolean = false,
+  isRunTest:            Boolean = false,
+  isVerbose:            Boolean = false,
+  displayBase:          Int     = 10,
+  testerSeed:           Long    = System.currentTimeMillis,
+  testCmd:              Seq[String] = Seq.empty,
+  moreVcsFlags:         Seq[String] = Seq.empty,
+  moreVcsCFlags:        Seq[String] = Seq.empty,
+  vcsCommandEdits:      String = "",
+  backendName:          String  = "treadle",
+  logFileName:          String  = "",
+  waveform:             Option[File] = None,
+  moreIvlFlags:         Seq[String] = Seq.empty,
+  moreIvlCFlags:        Seq[String] = Seq.empty,
+  ivlCommandEdits:      String = "",
+  suppressVerilatorVCD: Boolean = false
+) extends ComposableOptions
 
 object TesterOptions {
   val VcsFileCommands: Regex = """file:(.+)""".r
@@ -127,6 +129,11 @@ trait HasTesterOptions {
     .abbr("tts")
     .foreach { x => testerOptions = testerOptions.copy(testerSeed = x) }
     .text("provides a seed for random number generator")
+
+  parser.opt[Unit]("suppress-verilator-vcd")
+    .abbr("tsvv")
+    .foreach { _ => testerOptions = testerOptions.copy(suppressVerilatorVCD = true) }
+    .text(s"provides a way to turn of the default generation of vcd files in verilator simulations")
 }
 
 class TesterOptionsManager

--- a/src/main/scala/chisel3/iotesters/TesterOptions.scala
+++ b/src/main/scala/chisel3/iotesters/TesterOptions.scala
@@ -29,7 +29,7 @@ case class TesterOptions(
   moreIvlFlags:         Seq[String] = Seq.empty,
   moreIvlCFlags:        Seq[String] = Seq.empty,
   ivlCommandEdits:      String = "",
-  suppressVerilatorVCD: Boolean = false
+  generateVcdOutput:    String = ""
 ) extends ComposableOptions
 
 object TesterOptions {
@@ -130,10 +130,17 @@ trait HasTesterOptions {
     .foreach { x => testerOptions = testerOptions.copy(testerSeed = x) }
     .text("provides a seed for random number generator")
 
-  parser.opt[Unit]("suppress-verilator-vcd")
-    .abbr("tsvv")
-    .foreach { _ => testerOptions = testerOptions.copy(suppressVerilatorVCD = true) }
-    .text(s"provides a way to turn of the default generation of vcd files in verilator simulations")
+  parser.opt[String]("generate-vcd-output")
+    .abbr("tgvo")
+    .validate { x =>
+      if(Seq("on", "off").contains(x.toLowerCase)) {
+        parser.success
+      } else {
+        parser.failure("generateVcdOutput must be set to on or off")
+      }
+    }
+    .foreach { x => testerOptions = testerOptions.copy(generateVcdOutput = x) }
+    .text(s"""set this flag to "on" or "off", otherwise it defaults to on for verilator, off for scala backends""")
 }
 
 class TesterOptionsManager

--- a/src/main/scala/chisel3/iotesters/TreadleBackend.scala
+++ b/src/main/scala/chisel3/iotesters/TreadleBackend.scala
@@ -130,6 +130,12 @@ private[iotesters] object setupTreadleBackend {
     // invocation, run after updating compilerName so we only get one emitCircuit annotation
     val annos = firrtl.Driver.getAnnotations(optionsManager)
     optionsManager.firrtlOptions = optionsManager.firrtlOptions.copy(annotations = annos.toList)
+
+    // generate VcdOutput overrides setting of writeVcd
+    if(optionsManager.testerOptions.generateVcdOutput == "on") {
+      optionsManager.treadleOptions = optionsManager.treadleOptions.copy(writeVCD = true)
+    }
+
     chisel3.Driver.execute(optionsManager, dutGen) match {
       case ChiselExecutionSuccess(Some(circuit), _, Some(firrtlExecutionResult)) =>
         val dut = getTopModule(circuit).asInstanceOf[T]

--- a/src/main/scala/chisel3/iotesters/VerilatorBackend.scala
+++ b/src/main/scala/chisel3/iotesters/VerilatorBackend.scala
@@ -210,6 +210,7 @@ private[iotesters] object setupVerilatorBackend {
     optionsManager.chiselOptions = optionsManager.chiselOptions.copy(
       runFirrtlCompiler = false
     )
+
     val dir = new File(optionsManager.targetDirName)
 
     // Generate CHIRRTL
@@ -219,7 +220,7 @@ private[iotesters] object setupVerilatorBackend {
         val chirrtl = firrtl.Parser.parse(emitted)
         val dut = getTopModule(circuit).asInstanceOf[T]
 
-        val suppressVerilatorVCD = optionsManager.testerOptions.suppressVerilatorVCD
+        val suppressVerilatorVCD = optionsManager.testerOptions.generateVcdOutput == "off"
 
         // This makes sure annotations for command line options get created
         val externalAnnotations = firrtl.Driver.getAnnotations(optionsManager)

--- a/src/main/scala/chisel3/iotesters/VerilatorBackend.scala
+++ b/src/main/scala/chisel3/iotesters/VerilatorBackend.scala
@@ -219,6 +219,8 @@ private[iotesters] object setupVerilatorBackend {
         val chirrtl = firrtl.Parser.parse(emitted)
         val dut = getTopModule(circuit).asInstanceOf[T]
 
+        val suppressVerilatorVCD = optionsManager.testerOptions.suppressVerilatorVCD
+
         // This makes sure annotations for command line options get created
         val externalAnnotations = firrtl.Driver.getAnnotations(optionsManager)
 
@@ -260,7 +262,8 @@ private[iotesters] object setupVerilatorBackend {
             circuit.name,
             dir,
             vSources = Seq(),
-            cppHarnessFile
+            cppHarnessFile,
+            suppressVerilatorVCD
           ).! == 0
         )
         assert(chisel3.Driver.cppToExe(circuit.name, dir).! == 0)

--- a/src/test/scala/examples/GCDSpec.scala
+++ b/src/test/scala/examples/GCDSpec.scala
@@ -2,10 +2,12 @@
 
 package examples
 
+import java.io.File
+
 import chisel3._
 import chisel3.util._
 import chisel3.iotesters._
-import org.scalatest.{Matchers, FlatSpec}
+import org.scalatest.{FlatSpec, Matchers}
 
 object RealGCD2 {
   val num_width = 16
@@ -109,6 +111,32 @@ class GCDSpec extends FlatSpec with Matchers {
     iotesters.Driver.execute(() => new RealGCD2, manager) { c =>
       new GCDPeekPokeTester(c)
     } should be (true)
+  }
+
+  "using verilator backend with suppress-verilator-backend" should "not create a vcd" in {
+    iotesters.Driver.execute(
+      Array("--backend-name", "verilator", "--suppress-verilator-vcd",
+        "--target-dir", "test_run_dir/gcd_no_vcd", "--top-name", "gcd_no_vcd"),
+      () => new RealGCD2
+    ) {
+
+      c => new GCDPeekPokeTester(c)
+    } should be(true)
+
+    new File("test_run_dir/gcd_no_vcd/RealGCD2.vcd").exists() should be (false)
+  }
+
+  "using verilator default behavior" should "create a vcd" in {
+    iotesters.Driver.execute(
+      Array("--backend-name", "verilator",
+        "--target-dir", "test_run_dir/gcd_make_vcd", "--top-name", "gcd_make_vcd"),
+      () => new RealGCD2
+    ) {
+
+      c => new GCDPeekPokeTester(c)
+    } should be(true)
+
+    new File("test_run_dir/gcd_make_vcd/RealGCD2.vcd").exists() should be (true)
   }
 }
 

--- a/src/test/scala/examples/GCDSpec.scala
+++ b/src/test/scala/examples/GCDSpec.scala
@@ -115,7 +115,7 @@ class GCDSpec extends FlatSpec with Matchers {
 
   "using verilator backend with suppress-verilator-backend" should "not create a vcd" in {
     iotesters.Driver.execute(
-      Array("--backend-name", "verilator", "--suppress-verilator-vcd",
+      Array("--backend-name", "verilator", "--generate-vcd-output", "off",
         "--target-dir", "test_run_dir/gcd_no_vcd", "--top-name", "gcd_no_vcd"),
       () => new RealGCD2
     ) {


### PR DESCRIPTION
- Add new flag suppressVerilatorVCD to TesterOptions
- setUpVerilatorBackend looks at this flag and uses it
- added tests to show that this works
- This combined with [firrtl pr 794](https://github.com/freechipsproject/firrtl/pull/794/files) resolves [chisel issue 808](https://github.com/freechipsproject/chisel3/issues/808)