### PR TITLE
Add support for vcs command line options to verilator.

### DIFF
--- a/src/main/scala/chisel3/iotesters/PeekPokeTesterUtils.scala
+++ b/src/main/scala/chisel3/iotesters/PeekPokeTesterUtils.scala
@@ -86,44 +86,143 @@ private[iotesters] object bigIntToStr {
   }
 }
 
-private[iotesters] object verilogToIVL {
-  def constructIvlFlags(
-      topModule: String,
-      dir: java.io.File,
-      moreIvlFlags: Seq[String] = Seq.empty[String]): Seq[String] = {
+/** An EditableBuildCSimulatorCommand provides methods for assembling a system command string from provided flags and editing specifications.
+  * This is a trait to facilitate expansion (for more C-based simulators) and testing.
+  */
+trait EditableBuildCSimulatorCommand {
+  val prefix: String  // prefix to be used for error messages
 
-    val blackBoxVerilogList = {
-      val list_file = new File(dir, firrtl.transforms.BlackBoxSourceHelper.fileListName)
-      if(list_file.exists()) {
-        Seq("-f", list_file.getAbsolutePath)
-      }
-      else {
-        Seq.empty[String]
-      }
+  /** If we have a list of black box verilog implementations, return a sequence suitable for sourcing the file containing the list.
+    *
+    * @param dir - directory in which the file should exist
+    * @return sequence of strings (suitable for passing as arguments to the simulator builder) specifying a flag and the absolute path to the file.
+    */
+  def blackBoxVerilogList(dir: java.io.File): Seq[String] = {
+    val list_file = new File(dir, firrtl.transforms.BlackBoxSourceHelper.fileListName)
+    if(list_file.exists()) {
+      Seq("-f", list_file.getAbsolutePath)
+    } else {
+      Seq.empty[String]
     }
+  }
+
+  /** Compose user-supplied flags with the default flags.
+    * @param topModule - the name of the module to be simulated
+    * @param dir - the directory in which to build the simulation
+    * @param flags - general flags for the build process
+    * @param cFlags - C flags for the build process
+    * @return tuple containing a sequence of the composed general flags and a sequence of the composed C flags
+    */
+  def composeFlags(
+                      topModule: String,
+                      dir: java.io.File,
+                      moreIvlFlags: Seq[String] = Seq.empty[String],
+                      moreIvlCFlags: Seq[String] = Seq.empty[String]): (Seq[String], Seq[String])
+
+  /** Given two sets of flags (non-CFlags and CFlags), return the composed command (prior to editting).
+    * @param topModule - the name of the module to be simulated
+    * @param dir - the directory in which to build the simulation
+    * @param flags - general flags for the build process
+    * @param cFlags - C flags for the build process
+    * @return a string (suitable for "bash -c") to build the simulator.
+    */
+  def composeCommand(
+                        topModule: String,
+                        dir: java.io.File,
+                        flags: Seq[String],
+                        cFlags: Seq[String]
+                    ): String
+
+  /** Edit a C simulator build string.
+    *
+    * @param buildCommand - generated command line to be passed to the build process ("bash -c <cmd>")
+    * @param editCommands - commands to edit the generated command line
+    * @return edited command string
+    */
+  def editCSimulatorCommand(
+                               buildCommand: String,
+                               editCommands: String
+                           ): String = {
+
+    val commandEditor = CommandEditor(editCommands, prefix)
+    val editedCommand = commandEditor(buildCommand)
+    editedCommand
+  }
+
+  /** Construct a command to build a C-based simulator.
+    *
+    * @param topModule - the name of the module to be simulated
+    * @param dir - the directory in which to build the simulation
+    * @param flags - user flags to be passed to the build process - these will be composed with the default flags for the builder
+    * @param cFlags - user C flags to be passed to the build process - these will be composed with the default C flags for the builder
+    * @param editCommands - commands to edit the generated command line
+    * @return string representing the bash command to be executed
+    *
+    * @note This method will call `composeFlags()` internally, so the flag parameters should '''NOT''' include the default flags for the builder.
+    */
+  def constructCSimulatorCommand(
+                                         topModule: String,
+                                         dir: java.io.File,
+                                         harness:  java.io.File,
+                                         flags: Seq[String] = Seq.empty[String],
+                                         cFlags: Seq[String] = Seq.empty[String]
+                                     ): String
+}
+
+private[iotesters] object verilogToIVL extends EditableBuildCSimulatorCommand {
+  val prefix = "ivl-command-edit"
+  def composeCommand(
+                      topModule: String,
+                      dir: java.io.File,
+                      flags: Seq[String],
+                      cFlags: Seq[String]
+                    ): String = {
+    Seq("cd", dir.toString, "&&") ++
+      Seq("g++") ++ cFlags ++ Seq("vpi.cpp", "vpi_register.cpp", "&&") ++
+      Seq("iverilog") ++ flags mkString " "
+  }
+
+  def composeFlags(
+               topModule: String,
+               dir: java.io.File,
+               moreIvlFlags: Seq[String] = Seq.empty[String],
+               moreIvlCFlags: Seq[String] = Seq.empty[String]): (Seq[String], Seq[String]) = {
 
     val ivlFlags = Seq(
       "-m ./%s/%s.vpi".format(dir.toString, topModule),
       "-g2005-sv",
-      "-DCLOCK_PERIOD=1") ++
-      moreIvlFlags ++
-      blackBoxVerilogList
-
-    ivlFlags
-  }
-
-  def constructIvlCFlags(
-      topModule: String,
-      dir: java.io.File,
-      moreIvlCFlags: Seq[String] = Seq.empty[String]): Seq[String] = {
-
-    val DefaultCcFlags = Seq("-I$IVL_HOME", s"-I$dir", "-fPIC", "-std=c++11", "-lvpi", "-lveriuser", "-shared")
+      "-DCLOCK_PERIOD=1"
+    ) ++ moreIvlFlags
 
     val ivlCFlags = Seq(
-      s"-o $topModule.vpi", "-D__ICARUS__") ++ 
-      DefaultCcFlags ++ moreIvlCFlags
+      s"-o $topModule.vpi",
+      "-D__ICARUS__",
+      "-I$IVL_HOME",
+      s"-I$dir",
+      "-fPIC",
+      "-std=c++11",
+      "-lvpi",
+      "-lveriuser",
+      "-shared"
+    ) ++ moreIvlCFlags
 
-    ivlCFlags
+    (ivlFlags, ivlCFlags)
+  }
+
+  def constructCSimulatorCommand(
+                                    topModule: String,
+                                    dir: java.io.File,
+                                    harness:  java.io.File,
+                                    iFlags: Seq[String] = Seq.empty[String],
+                                    iCFlags: Seq[String] = Seq.empty[String]
+                                ): String = {
+
+    val (cFlags, cCFlags) = composeFlags(topModule, dir,
+      iFlags ++ blackBoxVerilogList(dir) ++ Seq("-o", topModule, s"$topModule.v", harness.toString),
+      iCFlags
+    )
+
+    composeCommand(topModule, dir, cFlags, cCFlags)
   }
 
   def apply(
@@ -134,40 +233,32 @@ private[iotesters] object verilogToIVL {
     moreIvlCFlags: Seq[String] = Seq.empty[String],
     editCommands: String = ""): ProcessBuilder = {
 
-    val ivlFlags = constructIvlFlags(topModule, dir, moreIvlFlags)
-    val ivlCFlags = constructIvlCFlags(topModule, dir, moreIvlCFlags)
-
-    val cmd = Seq("cd", dir.toString, "&&") ++
-                Seq("g++") ++ ivlCFlags ++ Seq("vpi.cpp", "vpi_register.cpp", "&&") ++
-                Seq("iverilog") ++ ivlFlags ++ Seq("-o", topModule, s"$topModule.v", ivlHarness.toString) mkString " "
-
-    val commandEditor = CommandEditor(editCommands, "ivl-command-edit")
-    val finalCommand = commandEditor(cmd)
+    val finalCommand = editCSimulatorCommand(constructCSimulatorCommand(topModule, dir, ivlHarness, moreIvlFlags, moreIvlCFlags), editCommands)
     println(s"$finalCommand")
 
     Seq("bash", "-c", finalCommand)
   }
 }
 
-private[iotesters] object verilogToVCS {
-  def constructVcsFlags(
-      topModule: String,
-      dir: java.io.File,
-      moreVcsFlags: Seq[String] = Seq.empty[String],
-      moreVcsCFlags: Seq[String] = Seq.empty[String]): Seq[String] = {
+private[iotesters] object verilogToVCS extends EditableBuildCSimulatorCommand {
+  val prefix = "vcs-command-edit"
+  override def composeCommand(
+                                 topModule: String,
+                                 dir: java.io.File,
+                                 flags: Seq[String],
+                                 cFlags: Seq[String]): String = {
+    Seq("cd", dir.toString, "&&", "vcs") ++ flags mkString " "
 
-    val DefaultCcFlags = Seq("-I$VCS_HOME/include", "-I$dir", "-fPIC", "-std=c++11")
-    val ccFlags = DefaultCcFlags ++ moreVcsCFlags
+  }
 
-    val blackBoxVerilogList = {
-      val list_file = new File(dir, firrtl.transforms.BlackBoxSourceHelper.fileListName)
-      if(list_file.exists()) {
-        Seq("-f", list_file.getAbsolutePath)
-      }
-      else {
-        Seq.empty[String]
-      }
-    }
+
+  def composeFlags(
+                      topModule: String,
+                      dir: java.io.File,
+                      moreVcsFlags: Seq[String] = Seq.empty[String],
+                      moreVcsCFlags: Seq[String] = Seq.empty[String]): (Seq[String], Seq[String]) = {
+
+    val ccFlags = Seq("-I$VCS_HOME/include", "-I$dir", "-fPIC", "-std=c++11") ++ moreVcsCFlags
 
     val vcsFlags = Seq("-full64",
       "-quiet",
@@ -181,10 +272,25 @@ private[iotesters] object verilogToVCS {
       "-P", "vpi.tab",
       "-cpp", "g++", "-O2", "-LDFLAGS", "-lstdc++",
       "-CFLAGS", "\"%s\"".format(ccFlags mkString " ")) ++
-      moreVcsFlags ++
-      blackBoxVerilogList
+      moreVcsFlags
 
-    vcsFlags
+    (vcsFlags, ccFlags)
+  }
+
+  def constructCSimulatorCommand(
+                                    topModule: String,
+                                    dir: java.io.File,
+                                    harness:  java.io.File,
+                                    iFlags: Seq[String] = Seq.empty[String],
+                                    iCFlags: Seq[String] = Seq.empty[String]
+                                ): String = {
+
+    val (cFlags, cCFlags) = composeFlags(topModule, dir,
+      iFlags ++ blackBoxVerilogList(dir) ++ Seq("-o", topModule, s"$topModule.v", harness.toString, "vpi.cpp"),
+      iCFlags
+    )
+
+    composeCommand(topModule, dir, cFlags, cCFlags)
   }
 
   def apply(
@@ -195,46 +301,39 @@ private[iotesters] object verilogToVCS {
     moreVcsCFlags: Seq[String] = Seq.empty[String],
     editCommands: String = ""): ProcessBuilder = {
 
-    val vcsFlags = constructVcsFlags(topModule, dir, moreVcsFlags, moreVcsCFlags)
-
-    val cmd = Seq("cd", dir.toString, "&&", "vcs") ++ vcsFlags ++ Seq(
-      "-o", topModule, s"$topModule.v", vcsHarness.toString, "vpi.cpp") mkString " "
-
-    val commandEditor = CommandEditor(editCommands, "vcs-command-edit")
-    val finalCommand = commandEditor(cmd)
+    val finalCommand = editCSimulatorCommand(constructCSimulatorCommand(topModule, dir, vcsHarness, moreVcsFlags, moreVcsCFlags), editCommands)
     println(s"$finalCommand")
 
     Seq("bash", "-c", finalCommand)
   }
 }
 
-private[iotesters] object verilogToVerilator {
-  def constructVerilatorFlags(
-                           topModule: String,
-                           dir: File,
-                           cppHarness: File,
-                           moreVerilatorFlags: Seq[String] = Seq.empty[String],
-                           moreVerilatorCFlags: Seq[String] = Seq.empty[String]): Seq[String] = {
+private[iotesters] object verilogToVerilator extends EditableBuildCSimulatorCommand {
+  val prefix = "verilator-command-edit"
+  override def composeCommand(
+                                 topModule: String,
+                                 dir: java.io.File,
+                                 flags: Seq[String],
+                                 cFlags: Seq[String]): String = {
+    Seq("cd", dir.getAbsolutePath, "&&", "verilator", "--cc", s"$topModule.v") ++ flags mkString " "
 
-    val DefaultCcFlags = Seq(
+  }
+
+  def composeFlags(
+               topModule: String,
+               dir: File,
+               moreVerilatorFlags: Seq[String] = Seq.empty[String],
+               moreVerilatorCFlags: Seq[String] = Seq.empty[String]): (Seq[String], Seq[String]) = {
+
+    val ccFlags = Seq(
       "-Wno-undefined-bool-conversion",
       "-O1",
       s"-DTOP_TYPE=V$topModule",
       "-DVL_USER_FINISH",
-      s"-include V$topModule.h"    )
-    val ccFlags = DefaultCcFlags ++ moreVerilatorCFlags
+      s"-include V$topModule.h"
+    ) ++ moreVerilatorCFlags
 
-    val blackBoxVerilogList = {
-      val list_file = new File(dir, firrtl.transforms.BlackBoxSourceHelper.fileListName)
-      if(list_file.exists()) {
-        Seq("-f", list_file.getAbsolutePath)
-      }
-      else {
-        Seq.empty[String]
-      }
-    }
-
-    val verilatorFlags = blackBoxVerilogList ++ Seq("--assert",
+    val verilatorFlags = Seq("--assert",
       "-Wno-fatal",
       "-Wno-WIDTH",
       "-Wno-STMTDLY",
@@ -244,28 +343,36 @@ private[iotesters] object verilogToVerilator {
       s"+define+PRINTF_COND=!$topModule.reset",
       s"+define+STOP_COND=!$topModule.reset",
       "-CFLAGS", "\"%s\"".format(ccFlags mkString " "),
-      "-Mdir", dir.getAbsolutePath,
-      "--exe", cppHarness.getAbsolutePath
+      "-Mdir", dir.getAbsolutePath
     ) ++ moreVerilatorFlags
+    (verilatorFlags, ccFlags)
+  }
 
-    verilatorFlags
+  def constructCSimulatorCommand(
+                                    topModule: String,
+                                    dir: java.io.File,
+                                    harness:  java.io.File,
+                                    iFlags: Seq[String] = Seq.empty[String],
+                                    iCFlags: Seq[String] = Seq.empty[String]
+                                ): String = {
+
+    val (cFlags, cCFlags) = composeFlags(topModule, dir,
+      blackBoxVerilogList(dir) ++ Seq("--exe", harness.getAbsolutePath) ++ iFlags,
+      iCFlags
+    )
+
+    composeCommand(topModule, dir, cFlags, cCFlags)
   }
 
   def apply(
                topModule: String,
                dir: File,
-               vSources: Seq[File],
                verilatorHarness: File,
                moreVerilatorFlags: Seq[String] = Seq.empty[String],
                moreVerilatorCFlags: Seq[String] = Seq.empty[String],
                editCommands: String = ""): ProcessBuilder = {
 
-    val verilatorFlags = constructVerilatorFlags(topModule, dir, verilatorHarness, moreVerilatorFlags, moreVerilatorCFlags)
-
-    val cmd = Seq("cd", dir.getAbsolutePath, "&&", "verilator", "--cc", s"$topModule.v") ++ verilatorFlags mkString " "
-
-    val commandEditor = CommandEditor(editCommands, "vcs-command-edit")
-    val finalCommand = commandEditor(cmd)
+    val finalCommand = editCSimulatorCommand(constructCSimulatorCommand(topModule, dir, verilatorHarness, moreVerilatorFlags, moreVerilatorCFlags), editCommands)
     println(s"$finalCommand")
 
     Seq("bash", "-c", finalCommand)

--- a/src/main/scala/chisel3/iotesters/VerilatorBackend.scala
+++ b/src/main/scala/chisel3/iotesters/VerilatorBackend.scala
@@ -263,7 +263,6 @@ private[iotesters] object setupVerilatorBackend {
           verilogToVerilator(
             circuit.name,
             dir,
-            vSources = Seq(),
             cppHarnessFile,
             moreVerilatorFlags = verilatorFlags,
             moreVerilatorCFlags = optionsManager.testerOptions.moreVcsCFlags,

--- a/src/main/scala/chisel3/iotesters/VerilatorBackend.scala
+++ b/src/main/scala/chisel3/iotesters/VerilatorBackend.scala
@@ -258,13 +258,16 @@ private[iotesters] object setupVerilatorBackend {
         cppHarnessWriter.append(emittedStuff)
         cppHarnessWriter.close()
 
+        val verilatorFlags = optionsManager.testerOptions.moreVcsFlags ++ { if (suppressVerilatorVCD) Seq() else Seq("--trace") }
         assert(
-          chisel3.Driver.verilogToCpp(
+          verilogToVerilator(
             circuit.name,
             dir,
             vSources = Seq(),
             cppHarnessFile,
-            suppressVerilatorVCD
+            moreVerilatorFlags = verilatorFlags,
+            moreVerilatorCFlags = optionsManager.testerOptions.moreVcsCFlags,
+            editCommands = optionsManager.testerOptions.vcsCommandEdits
           ).! == 0
         )
         assert(chisel3.Driver.cppToExe(circuit.name, dir).! == 0)

--- a/src/test/scala/chisel3/iotesters/ToolChainSpec.scala
+++ b/src/test/scala/chisel3/iotesters/ToolChainSpec.scala
@@ -7,74 +7,148 @@ import java.io.{File, PrintWriter}
 import org.scalatest.{FreeSpec, Matchers}
 
 class ToolChainSpec extends FreeSpec with Matchers {
-  "Ability to augment the VCS command lines" - {
-    "Can add arguments to VCS flags" in {
-      val flag1 = "--dog"
-      val flag2 = "--cat"
+  case class EditableBuildCommandTest(
+      name: String,
+      builder: EditableBuildCSimulatorCommand,
+      gFlagName: String,
+      gFlagFieldName: String,
+      cFlagName: String,
+      cFlagFieldName: String,
+      editName: String,
+      editFieldName: String
+                                     )
+  val editableBuildCommandTests = List(
+    EditableBuildCommandTest("verilogToVCS", verilogToVCS, "--more-vcs-flags", "moreVcsFlags", "--more-vcs-c-flags", "moreVcsCFlags", "--vcs-command-edits", "vcsCommandEdits"),
+    EditableBuildCommandTest("verilogToIVL", verilogToIVL, "--more-ivl-flags", "moreIvlFlags", "--more-ivl-c-flags", "moreIvlCFlags", "--ivl-command-edits", "ivlCommandEdits"),
+    EditableBuildCommandTest("verilogToVerilator", verilogToVerilator, "--more-vcs-flags", "moreVcsFlags", "--more-vcs-c-flags", "moreVcsCFlags", "--vcs-command-edits", "vcsCommandEdits"),
+  )
 
-      val manager = new TesterOptionsManager
+  val dummyTop = "top"
+  val dummyHarness = new File("harness.v")
+  val dummyDir = new File("dir")
 
-      manager.parse(Array("--more-vcs-flags", s"$flag1 $flag2")) should be (true)
+  for ( ebct <- editableBuildCommandTests) {
+    val builderName = ebct.name
+    val builder = ebct.builder
 
-      manager.testerOptions.moreVcsFlags.length should be (2)
+    s"Ability to augment the VCS command lines - $builderName" - {
 
-      val vcsFlags = verilogToVCS.constructVcsFlags(
-        "top", new File("dir"), manager.testerOptions.moreVcsFlags, manager.testerOptions.moreVcsCFlags)
+      "Can add arguments to VCS flags" in {
+        val flag1 = "--dog"
+        val flag2 = "--cat"
 
-      vcsFlags.contains(flag1) should be (true)
-      vcsFlags.contains(flag2) should be (true)
+        val manager = new TesterOptionsManager
+
+        manager.parse(Array(ebct.gFlagName, s"$flag1 $flag2")) should be (true)
+        // TODO It would be nice if we could do this dynamically (based on reflection).
+        val gFlags: Seq[String] = ebct.gFlagFieldName match {
+          case "moreVcsFlags" => manager.testerOptions.moreVcsFlags
+          case "moreIvlFlags" => manager.testerOptions.moreIvlFlags
+        }
+        val cFlags: Seq[String] = ebct.cFlagFieldName match {
+          case "moreVcsCFlags" => manager.testerOptions.moreVcsCFlags
+          case "moreIvlCFlags" => manager.testerOptions.moreIvlCFlags
+        }
+
+        gFlags.length should be (2)
+
+        val (vcsFlags, vcsCFlags) = builder.composeFlags(dummyTop, dummyDir, gFlags, cFlags)
+
+        vcsFlags.contains(flag1) should be (true)
+        vcsFlags.contains(flag2) should be (true)
+      }
+
+      s"Can add arguments to VCS CFLAGS - $builderName" in {
+        val cFlag1 = "-XYZ"
+        val cFlag2 = "-DFLAG=VALUE"
+        val manager = new TesterOptionsManager
+
+        manager.parse(Array(ebct.cFlagName, s"$cFlag1 $cFlag2")) should be (true)
+
+        // TODO It would be nice if we could do this dynamically (based on reflection).
+        val gFlags: Seq[String] = ebct.gFlagFieldName match {
+          case "moreVcsFlags" => manager.testerOptions.moreVcsFlags
+          case "moreIvlFlags" => manager.testerOptions.moreIvlFlags
+        }
+        val cFlags: Seq[String] = ebct.cFlagFieldName match {
+          case "moreVcsCFlags" => manager.testerOptions.moreVcsCFlags
+          case "moreIvlCFlags" => manager.testerOptions.moreIvlCFlags
+        }
+        cFlags.length should be (2)
+
+        val (vcsFlags, vcsCFlags) = builder.composeFlags(
+          dummyTop, dummyDir, gFlags, cFlags)
+
+        vcsCFlags.contains(cFlag1) should be (true)
+        vcsCFlags.contains(cFlag2) should be (true)
+      }
     }
-    "Can add arguments to VCS CFLAGS" in {
-      val cFlag1 = "-XYZ"
-      val cFlag2 = "-DFLAG=VALUE"
-      val manager = new TesterOptionsManager
 
-      manager.parse(Array("--more-vcs-c-flags", s"$cFlag1 $cFlag2")) should be (true)
+    s"Ability to edit vcs command line - $builderName" - {
+      // Build the expected command (default arguments)
+      val expectedCommand = builder.constructCSimulatorCommand(dummyTop, dummyDir, dummyHarness)
+      val expectedMultipleEditVCSCommand = """cd dir && vcs -full64 -loud -timescale=1ns/1ps -debug_pp -Mdir=top.csrc +vcs+lic+wait +vcs+initreg+random +define+CLOCK_PERIOD=1 -P vpi.tab -cpp g++ -O2 -LDFLAGS -lstdc++ -CFLAGS "-I$VCS_HOME/include -I$dir -fPIC -std=c++11" -o top top.v harness.v vpi.cpp"""
 
-      manager.testerOptions.moreVcsCFlags.length should be (2)
+      "can be done from a single edit on command line" in {
+        val dummyArg = "-A-dummy-arg"
+        val manager = new TesterOptionsManager
 
-      val vcsFlags = verilogToVCS.constructVcsFlags(
-        "top", new File("dir"), manager.testerOptions.moreVcsFlags, manager.testerOptions.moreVcsCFlags)
+        manager.parse(Array(ebct.editName, s"s/ $dummyArg//")) should be(true)
 
-      vcsFlags.exists(flag => flag.contains(cFlag1)) should be (true)
-      vcsFlags.exists(flag => flag.contains(cFlag2)) should be (true)
-    }
-  }
+        val editCommands = ebct.editFieldName match {
+          case "vcsCommandEdits" => manager.testerOptions.vcsCommandEdits
+          case "ivlCommandEdits" => manager.testerOptions.ivlCommandEdits
+        }
 
-  "Ability to edit vcs command line" - {
-    "can be done from a single edit on command line" in {
-      val command = """cd mydir && vcs -full64 -quiet -timescale=1ns/1ps -debug_pp -Mdir=bitwise_neg.csrc +v2k +vpi +vcs+lic+wait +vcs+initreg+random +define+CLOCK_PERIOD=1 -P vpi.tab -cpp g++ -O2 -LDFLAGS -lstdc++ -CFLAGS "-I$VCS_HOME/include -I$dir -fPIC -std=c++11" -o bitwise_neg bitwise_neg.v bitwise_neg-harness.v vpi.cpp"""
-      val expectedCommand = """cd mydir && vcs -quiet -timescale=1ns/1ps -debug_pp -Mdir=bitwise_neg.csrc +v2k +vpi +vcs+lic+wait +vcs+initreg+random +define+CLOCK_PERIOD=1 -P vpi.tab -cpp g++ -O2 -LDFLAGS -lstdc++ -CFLAGS "-I$VCS_HOME/include -I$dir -fPIC -std=c++11" -o bitwise_neg bitwise_neg.v bitwise_neg-harness.v vpi.cpp"""
-      val manager = new TesterOptionsManager
+        // Build the new command with the additional dummy argument(without editing)
+        val newCommand = builder.constructCSimulatorCommand(dummyTop, dummyDir, dummyHarness, Seq(dummyArg))
+        // Verify this new command doesn't match the "expected" (edited) command
+        newCommand should not be(expectedCommand)
+        newCommand should include (dummyArg)
 
-      manager.parse(Array("--vcs-command-edits", "s/-full64 //")) should be(true)
+        // Now build and edit the command and verify it matches the expected command.
+        val editedCommand = builder.editCSimulatorCommand(builder.constructCSimulatorCommand(dummyTop, dummyDir, dummyHarness, Seq(dummyArg)), editCommands)
 
-      val editor = CommandEditor(manager.testerOptions.vcsCommandEdits, "command-edit-test")
-      val newCommand = editor(command)
+        editedCommand should be(expectedCommand)
+      }
 
-      newCommand should be(expectedCommand)
-    }
+      "can be done from a multiple edits in a file" in {
+        val edits = Seq(
+          s"""verbose""",
+          s"""s/-quiet /-loud /""",
+          s"""s/\\+v2k \\+vpi //""",
+          s"""s/-lveriuser//"""
+        )
+        val fileName = s"edit-file.$builderName"
+        val file = new java.io.File(fileName)
+        val writer = new PrintWriter(file)
+        for (edit <- edits)
+          writer.println(edit)
+        writer.close()
 
-    "can be done from a multiple edits in a file" in {
-      val file = new java.io.File("edit-file")
-      val writer = new PrintWriter(file)
-      writer.println(s"""verbose""")
-      writer.println(s"""s/-quiet /-loud /""")
-      writer.println(s"""s/\\+v2k \\+vpi //""") // escape + because it's magic to regex
-      writer.close()
+        val manager = new TesterOptionsManager
 
-      val command = """cd mydir && vcs -full64 -quiet -timescale=1ns/1ps -debug_pp -Mdir=bitwise_neg.csrc +v2k +vpi +vcs+lic+wait +vcs+initreg+random +define+CLOCK_PERIOD=1 -P vpi.tab -cpp g++ -O2 -LDFLAGS -lstdc++ -CFLAGS "-I$VCS_HOME/include -I$dir -fPIC -std=c++11" -o bitwise_neg bitwise_neg.v bitwise_neg-harness.v vpi.cpp"""
-      val expectedCommand = """cd mydir && vcs -full64 -loud -timescale=1ns/1ps -debug_pp -Mdir=bitwise_neg.csrc +vcs+lic+wait +vcs+initreg+random +define+CLOCK_PERIOD=1 -P vpi.tab -cpp g++ -O2 -LDFLAGS -lstdc++ -CFLAGS "-I$VCS_HOME/include -I$dir -fPIC -std=c++11" -o bitwise_neg bitwise_neg.v bitwise_neg-harness.v vpi.cpp"""
-      val manager = new TesterOptionsManager
+        manager.parse(Array(ebct.editName, s"file:$fileName")) should be(true)
 
-      manager.parse(Array("--vcs-command-edits", "file:edit-file")) should be(true)
+        val editCommands = ebct.editFieldName match {
+          case "vcsCommandEdits" => manager.testerOptions.vcsCommandEdits
+          case "ivlCommandEdits" => manager.testerOptions.ivlCommandEdits
+        }
+        // Use the edit commands (as parsed) to edit the expected command
+        val expectedEditedCommand = CommandEditor(editCommands, "prep-exp")(expectedCommand)
 
-      val editor = CommandEditor(manager.testerOptions.vcsCommandEdits, "command-edit-test")
-      val newCommand = editor(command)
+        // Now build and edit command and verify it matches the expected command.
+        val editedCommand = builder.editCSimulatorCommand(builder.constructCSimulatorCommand(dummyTop, dummyDir, dummyHarness), editCommands)
+        file.delete()
 
-      newCommand should be(expectedCommand)
+        editedCommand should be(expectedEditedCommand)
+        // NOTE: Since we're using the CommandEditor in both cases (directly for verification and indirectly for test),
+        //  it could be broken and we wouldn't notice it. For at least one of the command builders, we've memorized the
+        //  expected edit results and we check against those to verify that CommandEditor is behaving as expected.
+        if (builder == verilogToVCS)
+          editedCommand.trim should be(expectedMultipleEditVCSCommand.trim)
 
-      file.delete()
+      }
     }
   }
 


### PR DESCRIPTION
We'd like to be able to use the current **vcs** command line options edit facility with **verilator**.

This replaces the direct call to `BackendCompilationUtilities.verilogToCpp()` with a local (chisel-testers) implementation which essentially duplicates the **vcs** facility.

Questions to be resolved:
- is this appropriate, or should we move this facility from **chisel-testers** to **firrtl**?
- the preliminary implementation tries to use existing **vcs** options instead of defining new **verilator** equivalents. Should we introduce distinct **verilator** options?
