### PR TITLE
[DO NOT MERGE] Proposed way to add enum support

### DIFF
--- a/src/main/scala/chisel3/iotesters/AdvTester.scala
+++ b/src/main/scala/chisel3/iotesters/AdvTester.scala
@@ -44,7 +44,7 @@ abstract class AdvTester[+T <: Module](dut: T,
   // Also, to ensure difference enforced, poke 'deprecated' and replaced with wire_poke
   def wire_poke(port: Bits, target: BigInt) = super.poke(port, target)
 
-  override def poke(port: Bits, target: BigInt) {
+  /*override*/ def poke(port: Bits, target: BigInt) {
     require(false, "poke hidden for AdvTester, use wire_poke or reg_poke")
   }
 

--- a/src/main/scala/chisel3/iotesters/FirrtlTerpBackend.scala
+++ b/src/main/scala/chisel3/iotesters/FirrtlTerpBackend.scala
@@ -23,7 +23,7 @@ private[iotesters] class FirrtlTerpBackend(
   def poke(signal: InstanceId, value: BigInt, off: Option[Int])
           (implicit logger: TestErrorLog, verbose: Boolean, base: Int): Unit = {
     signal match {
-      case port: Bits =>
+      case port: Element =>
         val name = portNames(port)
         interpretiveTester.poke(name, value)
         if (verbose) logger info s"  POKE $name <- ${bigIntToStr(value, base)}"
@@ -45,7 +45,7 @@ private[iotesters] class FirrtlTerpBackend(
   def peek(signal: InstanceId, off: Option[Int])
           (implicit logger: TestErrorLog, verbose: Boolean, base: Int): BigInt = {
     signal match {
-      case port: Bits =>
+      case port: Element =>
         val name = portNames(port)
         val result = interpretiveTester.peek(name)
         if (verbose) logger info s"  PEEK $name -> ${bigIntToStr(result, base)}"
@@ -63,7 +63,7 @@ private[iotesters] class FirrtlTerpBackend(
   def expect(signal: InstanceId, expected: BigInt, msg: => String)
             (implicit logger: TestErrorLog, verbose: Boolean, base: Int) : Boolean = {
     signal match {
-      case port: Bits =>
+      case port: Element =>
         val name = portNames(port)
         val got = interpretiveTester.peek(name)
         val good = got == expected

--- a/src/main/scala/chisel3/iotesters/PeekPokeTester.scala
+++ b/src/main/scala/chisel3/iotesters/PeekPokeTester.scala
@@ -5,7 +5,7 @@ package chisel3.iotesters
 import java.io.File
 
 import chisel3._
-import chisel3.core.{Aggregate, Element}
+import chisel3.core.{Aggregate, Element, EnumType}
 import PeekPokeTester.extractElementBits
 import chisel3.experimental.{FixedPoint, MultiIOModule}
 import chisel3.internal.firrtl.KnownBinaryPoint
@@ -14,6 +14,21 @@ import scala.collection.immutable.ListMap
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
+// A typeclass that defines the types we can poke, peek, or expect from
+trait Pokeable[-T]
+object Pokeable {
+  implicit object BitsPokeable extends Pokeable[Bits]
+  implicit object EnumPokeable extends Pokeable[EnumType]
+
+  trait IsRuntimePokeable // A trait that is applied to elements that were proven to be pokeable at runtime (usually in match statements)
+  implicit object UnapplyPokeable extends Pokeable[IsRuntimePokeable]
+
+  def unapply(elem: Element): Option[Element with IsRuntimePokeable] = elem match {
+    case _: Bits | _: EnumType => Some(elem.asInstanceOf[Element with IsRuntimePokeable])
+    case _ => None
+  }
+}
+
 // Provides a template to define tester transactions
 trait PeekPokeTests {
   def t: Long
@@ -21,18 +36,18 @@ trait PeekPokeTests {
   implicit def int(x: Boolean): BigInt
   implicit def int(x: Int):     BigInt
   implicit def int(x: Long):    BigInt
-  implicit def int(x: Bits):    BigInt
+  implicit def int[T <: Element: Pokeable](x: T): BigInt
   def println(msg: String = ""): Unit
   def reset(n: Int): Unit
   def step(n: Int): Unit
   def poke(path: String, x: BigInt): Unit
   def peek(path: String): BigInt
-  def poke(signal: Bits, x: BigInt): Unit
-  def pokeAt[T <: Bits](signal: Mem[T], x: BigInt, off: Int): Unit
-  def peek(signal: Bits): BigInt
-  def peekAt[T <: Bits](signal: Mem[T], off: Int): BigInt
+  def poke[T <: Element: Pokeable](signal: T, x: BigInt): Unit
+  def pokeAt[T <: Element: Pokeable](signal: Mem[T], x: BigInt, off: Int): Unit
+  def peek[T <: Element: Pokeable](signal: T): BigInt
+  def peekAt[T <: Element: Pokeable](signal: Mem[T], off: Int): BigInt
   def expect(good: Boolean, msg: => String): Boolean
-  def expect(signal: Bits, expected: BigInt, msg: => String = ""): Boolean
+  def expect[T <: Element: Pokeable](signal: T, expected: BigInt, msg: => String = ""): Boolean
   def finish: Boolean
 }
 
@@ -95,8 +110,8 @@ abstract class PeekPokeTester[+T <: MultiIOModule](
 
   /** Convert a Boolean to BigInt */
   implicit def int(x: Boolean): BigInt = if (x) 1 else 0
-  /** Convert Bits to BigInt */
-  implicit def int(x: Bits):    BigInt = x.litValue()
+  /** Convert Pokeables to BigInt */
+  implicit def int[T <: Element: Pokeable](x: T): BigInt = x.litValue()
 
   /**
     * Convert an Int to unsigned (effectively 32-bit) BigInt
@@ -135,16 +150,16 @@ abstract class PeekPokeTester[+T <: MultiIOModule](
 
   def peek(path: String) = backend.peek(path)
 
-  def poke(signal: Bits, value: BigInt): Unit = {
+  def poke[T <: Element: Pokeable](signal: T, value: BigInt): Unit = {
     if (!signal.isLit) backend.poke(signal, value, None)
     // TODO: Warn if signal.isLit
   }
 
-  def poke(signal: Bits, value: Int) {
+  def poke[T <: Element: Pokeable](signal: T, value: Int) {
     poke(signal, BigInt(value))
   }
 
-  def poke(signal: Bits, value: Long) {
+  def poke[T <: Element: Pokeable](signal: T, value: Long) {
     poke(signal, BigInt(value))
   }
 
@@ -158,11 +173,11 @@ abstract class PeekPokeTester[+T <: MultiIOModule](
     *
     * @param path - list of element names (presumably bundles) terminating in a non-bundle (i.e., Bits) element.
     * @param bundle - bundle containing the element
-    * @return the element (as Bits)
+    * @return the element (as Element)
     */
-  private def getBundleElement(path: List[String], bundle: ListMap[String, Data]): Bits = {
+  private def getBundleElement(path: List[String], bundle: ListMap[String, Data]): Element = {
     (path, bundle(path.head)) match {
-      case (head :: Nil, element: Bits) => element
+      case (head :: Nil, element: Element) => element
       case (head :: tail, b: Bundle) => getBundleElement(tail, b.elements)
       case _ => throw new Exception(s"peek/poke bundle element mismatch $path")
     }
@@ -178,19 +193,27 @@ abstract class PeekPokeTester[+T <: MultiIOModule](
     for ( (key, value) <- map) {
       val subKeys = key.split('.').toList
       val element = getBundleElement(subKeys, circuitElements)
-      poke(element, value)
+      element match {
+        case Pokeable(e) => poke(e, value)
+        case _ => throw new Exception(s"Cannot poke for type ${element.getClass}")
+      }
     }
   }
 
   def poke(signal: Aggregate, value: IndexedSeq[BigInt]): Unit =  {
-    (extractElementBits(signal) zip value.reverse).foreach(x => poke(x._1.asInstanceOf[Bits], x._2))
+    (extractElementBits(signal) zip value.reverse).foreach{ case (elem, value) =>
+      elem match {
+        case Pokeable(e) => poke(e, value)
+        case _ => throw new Exception(s"Cannot poke for type ${elem.getClass}")
+      }
+    }
   }
 
-  def pokeAt[TT <: Bits](data: Mem[TT], value: BigInt, off: Int): Unit = {
+  def pokeAt[TT <: Element: Pokeable](data: Mem[TT], value: BigInt, off: Int): Unit = {
     backend.poke(data, value, Some(off))
   }
 
-  def peek(signal: Bits):BigInt = {
+  def peek[T <: Element: Pokeable](signal: T):BigInt = {
     if (!signal.isLit) backend.peek(signal, None) else signal.litValue()
   }
 
@@ -203,10 +226,10 @@ abstract class PeekPokeTester[+T <: MultiIOModule](
   }
 
   def peek(signal: Aggregate): Seq[BigInt] =  {
-    extractElementBits(signal) map (x => backend.peek(x.asInstanceOf[Bits], None))
+    extractElementBits(signal) map (x => backend.peek(x.asInstanceOf[Element], None))
   }
 
-  /** Populate a map of names ("dotted Bundles) to Bits.
+  /** Populate a map of names ("dotted Bundles) to Elements.
     * TODO: Deal with Vecs
     *
     * @param map the map to be constructed
@@ -214,16 +237,16 @@ abstract class PeekPokeTester[+T <: MultiIOModule](
     * @param signalName the signal to be added to the map
     * @param signalData the signal object to be added to the map
     */
-  private def setBundleElement(map: mutable.LinkedHashMap[String, Bits], indexPrefix: ArrayBuffer[String], signalName: String, signalData: Data): Unit = {
+  private def setBundleElement(map: mutable.LinkedHashMap[String, Element], indexPrefix: ArrayBuffer[String], signalName: String, signalData: Data): Unit = {
     indexPrefix += signalName
     signalData match {
       case bundle: Bundle =>
         for ((name, value) <- bundle.elements) {
           setBundleElement(map, indexPrefix, name, value)
         }
-      case bits: Bits =>
+      case elem: Element =>
         val index = indexPrefix.mkString(".")
-        map(index) = bits
+        map(index) = elem
     }
     indexPrefix.remove(indexPrefix.size - 1)
   }
@@ -234,20 +257,21 @@ abstract class PeekPokeTester[+T <: MultiIOModule](
     * @return a map of signal names ("dotted" Bundle) to BigInt values.
     */
   def peek(signal: Bundle): mutable.LinkedHashMap[String, BigInt] = {
-    val bitsMap = mutable.LinkedHashMap[String, Bits]()
+    val elemMap = mutable.LinkedHashMap[String, Element]()
     val index = ArrayBuffer[String]()
-    // Populate the Bits map.
+    // Populate the Element map.
     for ((elementName, elementValue) <- signal.elements) {
-      setBundleElement(bitsMap, index, elementName, elementValue)
+      setBundleElement(elemMap, index, elementName, elementValue)
     }
     val bigIntMap = mutable.LinkedHashMap[String, BigInt]()
-    for ((name, bits) <- bitsMap) {
-      bigIntMap(name) = peek(bits)
+    elemMap.foreach {
+      case (name, Pokeable(e)) => bigIntMap(name) = peek(e)
     }
+
     bigIntMap
   }
 
-  def peekAt[TT <: Bits](data: Mem[TT], off: Int): BigInt = {
+  def peekAt[TT <: Element: Pokeable](data: Mem[TT], off: Int): BigInt = {
     backend.peek(data, Some(off))
   }
 
@@ -257,7 +281,7 @@ abstract class PeekPokeTester[+T <: MultiIOModule](
     good
   }
 
-  def expect(signal: Bits, expected: BigInt, msg: => String = ""): Boolean = {
+  def expect[T <: Element: Pokeable](signal: T, expected: BigInt, msg: => String = ""): Boolean = {
     if (!signal.isLit) {
       val good = backend.expect(signal, expected, msg)
       if (!good) fail
@@ -265,7 +289,7 @@ abstract class PeekPokeTester[+T <: MultiIOModule](
     } else expect(signal.litValue() == expected, s"${signal.litValue()} == $expected")
   }
 
-  def expect(signal: Bits, expected: Int, msg: => String): Boolean = {
+  def expect[T <: Element: Pokeable](signal: T, expected: Int, msg: => String): Boolean = {
     expect(signal, BigInt(expected), msg)
   }
 
@@ -276,7 +300,11 @@ abstract class PeekPokeTester[+T <: MultiIOModule](
   }
 
   def expect (signal: Aggregate, expected: IndexedSeq[BigInt]): Boolean = {
-    (extractElementBits(signal), expected.reverse).zipped.foldLeft(true) { (result, x) => result && expect(x._1.asInstanceOf[Bits], x._2)}
+    (extractElementBits(signal), expected.reverse).zipped.forall { case (elem, value) =>
+      elem match {
+        case Pokeable(e) => expect(e, value)
+      }
+    }
   }
 
   /** Return true or false if an aggregate signal (Bundle) matches the expected map of values.
@@ -287,12 +315,17 @@ abstract class PeekPokeTester[+T <: MultiIOModule](
     * @return true if the specified values match, false otherwise.
     */
   def expect (signal: Bundle, expected: Map[String, BigInt]): Boolean = {
-    val bitsMap = mutable.LinkedHashMap[String, Bits]()
+    val elemMap = mutable.LinkedHashMap[String, Element]()
     val index = ArrayBuffer[String]()
     for ((elementName, elementValue) <- signal.elements) {
-      setBundleElement(bitsMap, index, elementName, elementValue)
+      setBundleElement(elemMap, index, elementName, elementValue)
     }
-    expected.forall{ case ((name, value)) => expect(bitsMap(name), value) }
+    expected.forall { case (name, value) =>
+      elemMap(name) match {
+        case Pokeable(e) => expect(e, value)
+        case _ => throw new Exception("Cannot expect something that is not Bits or EnumType")
+      }
+    }
   }
 
   def finish: Boolean = {

--- a/src/main/scala/chisel3/iotesters/TreadleBackend.scala
+++ b/src/main/scala/chisel3/iotesters/TreadleBackend.scala
@@ -2,7 +2,7 @@
 
 package chisel3.iotesters
 
-import chisel3.{Bits, ChiselExecutionSuccess, Mem, assert}
+import chisel3.{Element, ChiselExecutionSuccess, Mem, assert}
 import chisel3.experimental.MultiIOModule
 import chisel3.internal.InstanceId
 import firrtl.{FirrtlExecutionFailure, FirrtlExecutionSuccess}
@@ -26,7 +26,7 @@ extends Backend(_seed = System.currentTimeMillis()) {
   def poke(signal: InstanceId, value: BigInt, off: Option[Int])
     (implicit logger: TestErrorLog, verbose: Boolean, base: Int): Unit = {
     signal match {
-      case port: Bits =>
+      case port: Element =>
         val name = portNames(port)
         treadleTester.poke(name, value)
         if (verbose) logger info s"  POKE $name <- ${bigIntToStr(value, base)}"
@@ -48,7 +48,7 @@ extends Backend(_seed = System.currentTimeMillis()) {
   def peek(signal: InstanceId, off: Option[Int])
     (implicit logger: TestErrorLog, verbose: Boolean, base: Int): BigInt = {
     signal match {
-      case port: Bits =>
+      case port: Element =>
         val name = portNames(port)
         val result = treadleTester.peek(name)
         if (verbose) logger info s"  PEEK $name -> ${bigIntToStr(result, base)}"
@@ -66,7 +66,7 @@ extends Backend(_seed = System.currentTimeMillis()) {
   def expect(signal: InstanceId, expected: BigInt, msg: => String)
     (implicit logger: TestErrorLog, verbose: Boolean, base: Int) : Boolean = {
     signal match {
-      case port: Bits =>
+      case port: Element =>
         val name = portNames(port)
         val got = treadleTester.peek(name)
         val good = got == expected


### PR DESCRIPTION
To address freechipsproject/chisel3#932, I am proposing that we add a new `Pokeable` typeclass that encompasses both `Bits` and `EnumType`s. To illustrate, I've converted `PeekPokeTester` over to the new `Pokeable` typeclass. I've tried to make the solution as elegant as possible, but unfortunately, the type signatures for some functions got longer.

If people are interested, they can check the `PeekPokeTester.scala` file to see how the new typeclass works. If I encounter pushback on this idea, then we can discuss the alternatives. Otherwise, I'll add tests and see if the other testers also have to be converted to the new typeclass.

I'm not sure how to add a DO NOT MERGE tag, but regardless, please don't merge until I've added the tests I need to add to make absolutely sure this solution is working. My tests so far have been very simple. I just wanted to put this out there early so I don't waste time on this thread if people are against it.