### PR TITLE
Add failing test showing problem with zero width inputs.

### DIFF
--- a/src/test/scala/chisel3/iotesters/ZeroWidthIOSpec.scala
+++ b/src/test/scala/chisel3/iotesters/ZeroWidthIOSpec.scala
@@ -1,0 +1,47 @@
+// See LICENSE for license details.
+
+import chisel3._
+import chisel3.iotesters._
+import chisel3.util._
+
+import org.scalatest._
+
+class MyZeroWidthDut extends chisel3.experimental.MultiIOModule {
+  val out0 = IO(Output(UInt(1.W)))
+  val in0 = IO(Input(UInt(0.W)))
+  val out1 = IO(Output(UInt(1.W)))
+  val in1 = IO(Input(UInt(1.W)))
+
+  out0 := in0
+  out1 := in1
+}
+
+class ZeroWidthIOTester(c: MyZeroWidthDut) extends PeekPokeTester(c) {
+  // poke(c.in0, 1)
+  expect(c.out0, 0) // in0 is width 0
+  poke(c.in1, 0)
+  expect(c.out1, 0)
+  poke(c.in1, 1)
+  expect(c.out1, 1)
+}
+
+class ZeroWidthIOSpec extends ChiselFlatSpec with Matchers {
+  behavior of "Zero Width IOs"
+
+  def test(args: Array[String]): Boolean =
+    iotesters.Driver.execute(args, () => new MyZeroWidthDut) {
+      c => new ZeroWidthIOTester(c)
+    }
+
+  it should "work with firrtl backend" in {
+    test(Array("-tbn", "firrtl")) should be (true)
+  }
+
+  it should "work with treadle backend" in {
+    test(Array("-tbn", "treadle")) should be (true)
+  }
+
+  it should "work with verilator backend" in {
+    test(Array("-tbn", "verilator")) should be (true)
+  }
+}


### PR DESCRIPTION
Zero width inputs break the verilator test harness. My suspicion is that there is mismatch in how to handle zero-width inputs between the part of the API that gets IDs and the peek/poke interface.