### PR TITLE
Fix RerunWithoutElaboration

### DIFF
--- a/src/test/scala/examples/RerunWithoutElaboratonAndCompileSpec.scala
+++ b/src/test/scala/examples/RerunWithoutElaboratonAndCompileSpec.scala
@@ -14,13 +14,12 @@ class RerunWithoutElaboratonAndCompileSpec extends FreeSpec with Matchers {
   "Demonstrate how to re-run a given test without recompiling" - {
     "build once" in {
       iotesters.Driver.execute(
-        Array("--backend-name", "verilator", "--target-dir", "build1", "--top-name", "PlusOne"), () => new PlusOne
+        Array("--backend-name", "verilator", "--target-dir", "test_run_dir/build1", "--top-name", "PlusOne"), () => new PlusOne
       ) { c =>
         new PlusOneTester(c, 0)
-      } should be (true)
-    }
-    "run again" in {
-      iotesters.Driver.run(() => new PlusOne, "./build1/VPlusOne") { c =>
+      } should be(true)
+
+      iotesters.Driver.run(() => new PlusOne, "./test_run_dir/build1/VPlusOne") { c =>
         new PlusOneTester(c, 33333)
       }
     }
@@ -41,7 +40,7 @@ class PlusOne extends Module {
   val io = IO(new Bundle {
     val dog = Input(UInt(64.W))
     val cat = Input(UInt(64.W))
-    val asp= Input(UInt(64.W))
+    val asp = Input(UInt(64.W))
     val fox = Input(UInt(64.W))
     val out = Output(UInt(64.W))
   })


### PR DESCRIPTION
- I believe this test was re-activated in broken form
  - Happened when fixed the verilator check method
- Made this into a single test to ensure sequential execution
- Moved the working directory for test into test_run_dir