### PR TITLE
Fix problem with circuits with zero width input using verilator

### DIFF
--- a/src/main/scala/chisel3/iotesters/SimApiInterface.scala
+++ b/src/main/scala/chisel3/iotesters/SimApiInterface.scala
@@ -14,12 +14,17 @@ import java.io.{File, PrintStream}
 import java.nio.channels.FileChannel
 
 private[iotesters] class SimApiInterface(dut: MultiIOModule, cmd: Seq[String]) {
+  //
+  // Construct maps for the input and output
+  // Remove zero length fields during the process
+  //
   val (inputsNameToChunkSizeMap, outputsNameToChunkSizeMap) = {
     val (inputs, outputs) = getPorts(dut)
     def genChunk(args: (Data, String)) = args match {
-      case (pin, name) => name -> ((pin.getWidth-1)/64 + 1)
+      case (pin, name) if pin.getWidth > 0 => Some(name -> ((pin.getWidth-1)/64 + 1))
+      case _ => None
     }
-    (ListMap((inputs map genChunk): _*), ListMap((outputs map genChunk): _*))
+    (ListMap((inputs flatMap genChunk): _*), ListMap((outputs flatMap genChunk): _*))
   }
   private object SIM_CMD extends Enumeration {
     val RESET, STEP, UPDATE, POKE, PEEK, FORCE, GETID, GETCHK, FIN = Value }

--- a/src/test/scala/chisel3/iotesters/ZeroWidthIOSpec.scala
+++ b/src/test/scala/chisel3/iotesters/ZeroWidthIOSpec.scala
@@ -1,0 +1,46 @@
+package chisel3.iotesters
+
+// See LICENSE for license details.
+
+import chisel3._
+import org.scalatest._
+
+class MyZeroWidthDut extends chisel3.experimental.MultiIOModule {
+  val out0 = IO(Output(UInt(1.W)))
+  val in0 = IO(Input(UInt(0.W)))
+  val out1 = IO(Output(UInt(1.W)))
+  val in1 = IO(Input(UInt(1.W)))
+
+  out0 := in0
+  out1 := in1
+}
+
+class ZeroWidthIOTester(c: MyZeroWidthDut) extends PeekPokeTester(c) {
+  // poke(c.in0, 1)
+  expect(c.out0, 0) // in0 is width 0
+  poke(c.in1, 0)
+  expect(c.out1, 0)
+  poke(c.in1, 1)
+  expect(c.out1, 1)
+}
+
+class ZeroWidthIOSpec extends ChiselFlatSpec with Matchers {
+  behavior of "Zero Width IOs"
+
+  def test(args: Array[String]): Boolean =
+    iotesters.Driver.execute(args, () => new MyZeroWidthDut) {
+      c => new ZeroWidthIOTester(c)
+    }
+
+  it should "work with firrtl backend" in {
+    test(Array("-tbn", "firrtl")) should be (true)
+  }
+
+  it should "work with treadle backend" in {
+    test(Array("-tbn", "treadle")) should be (true)
+  }
+
+  it should "work with verilator backend" in {
+    test(Array("-tbn", "verilator")) should be (true)
+  }
+}


### PR DESCRIPTION
DO NOT MERGE UNTIL PR #238 HAS BEEN MERGED
THIS SUPERSEDES PR #237 
- verilog 0.W input has been removed
- this fix removes them from the IO maps used to used to communicate with simulation
- provides a test that failed prior to the fix