### PR TITLE
Filter TargetDirAnnotations between Driver.execute

### DIFF
--- a/src/main/scala/chisel3/iotesters/FirrtlTerpBackend.scala
+++ b/src/main/scala/chisel3/iotesters/FirrtlTerpBackend.scala
@@ -131,7 +131,10 @@ private[iotesters] object setupFirrtlTerpBackend {
       optionsManager.interpreterOptions = optionsManager.interpreterOptions.copy(writeVCD = true)
     }
 
-    val annos = firrtl.Driver.getAnnotations(optionsManager)
+    val annos = firrtl.Driver.getAnnotations(optionsManager).filterNot {
+      case _: firrtl.options.TargetDirAnnotation => true
+      case _ => false
+    }
     optionsManager.firrtlOptions = optionsManager.firrtlOptions.copy(annotations = annos.toList)
     chisel3.Driver.execute(optionsManager, dutGen) match {
       case ChiselExecutionSuccess(Some(circuit), _, Some(firrtlExecutionResult)) =>

--- a/src/main/scala/chisel3/iotesters/TreadleBackend.scala
+++ b/src/main/scala/chisel3/iotesters/TreadleBackend.scala
@@ -128,7 +128,10 @@ private[iotesters] object setupTreadleBackend {
     optionsManager.firrtlOptions = optionsManager.firrtlOptions.copy(compilerName = "low")
     // Workaround to propagate Annotations generated from command-line options to second Firrtl
     // invocation, run after updating compilerName so we only get one emitCircuit annotation
-    val annos = firrtl.Driver.getAnnotations(optionsManager)
+    val annos = firrtl.Driver.getAnnotations(optionsManager).filterNot {
+      case _: firrtl.options.TargetDirAnnotation => true
+      case _ => false
+    }
     optionsManager.firrtlOptions = optionsManager.firrtlOptions.copy(annotations = annos.toList)
 
     // generate VcdOutput overrides setting of writeVcd


### PR DESCRIPTION
@ucbjrl: Here's one solution to the problem you identified here: https://github.com/freechipsproject/firrtl/pull/1005#issuecomment-487235820.

The underlying problem is that for target directories which are not `"."` this winds up generating two copies of the same `TargetDirAnnotation`. One by `Driver.getAnnotations` inside testers and another when `CommonOptions.toAnnotations` is used to convert `CommonOptions` to annotations before being passed to `FirrtlStage` in `firrtl.Driver`. This was not a problem before because `commonOptions.targetDirName` was the only thing checked inside of `firrtl.Driver` with the exception of any downstream transforms which may have relied on `TargetDirAnnotation`.

This likely motivates a more rapid push to migrate Stage/Phase into the Big6. Similar bugs may exist due to the interface if the following pattern is used:

1. An `ExecutionOptionsManager` is converted to an `AnnotationSeq`
2. The `AnnotationSeq` is inserted into the `ExecutionOptionsManager` (bug type 1: information is replicated and downstream Stage/Phases will see multiple copies of the same annotation)
3. The `ExecutionOptionsManager` is mutated (bug type 2: information is inconsistent and annotations will not be correctly updated).