### PR TITLE
Centralize (for testers) annotation filtering and filter out some more -

### DIFF
--- a/src/main/scala/chisel3/iotesters/Driver.scala
+++ b/src/main/scala/chisel3/iotesters/Driver.scala
@@ -284,6 +284,7 @@ object Driver {
       case _: firrtl.options.TargetDirAnnotation => true
       case _: logger.LogLevelAnnotation => true
       case _: firrtl.stage.FirrtlCircuitAnnotation => true
+      case _: firrtl.stage.InfoModeAnnotation => true
       case _ => false
     }
   }

--- a/src/main/scala/chisel3/iotesters/Driver.scala
+++ b/src/main/scala/chisel3/iotesters/Driver.scala
@@ -6,7 +6,7 @@ import chisel3._
 import chisel3.experimental.MultiIOModule
 import java.io.File
 
-import firrtl.{ExecutionOptionsManager, HasFirrtlOptions}
+import firrtl.annotations.Annotation
 import firrtl_interpreter._
 import logger.Logger
 
@@ -273,6 +273,19 @@ object Driver {
       case Some(f) => Seq(s"+waveform=$f")
     }
     run(dutGen, binary.toString +: args.toSeq)(testerGen)
+  }
+
+  /** Filter a sequence of annotations, ensuring problematic potential duplicates are removed.
+    * @param annotations Seq[Annotation] to be filtered
+    * @return filtered Seq[Annotation]
+    */
+  def filterAnnotations(annotations: Seq[Annotation]): Seq[Annotation] = {
+    annotations.filterNot {
+      case _: firrtl.options.TargetDirAnnotation => true
+      case _: logger.LogLevelAnnotation => true
+      case _: firrtl.stage.FirrtlCircuitAnnotation => true
+      case _ => false
+    }
   }
 }
 

--- a/src/main/scala/chisel3/iotesters/FirrtlTerpBackend.scala
+++ b/src/main/scala/chisel3/iotesters/FirrtlTerpBackend.scala
@@ -131,10 +131,7 @@ private[iotesters] object setupFirrtlTerpBackend {
       optionsManager.interpreterOptions = optionsManager.interpreterOptions.copy(writeVCD = true)
     }
 
-    val annos = firrtl.Driver.getAnnotations(optionsManager).filterNot {
-      case _: firrtl.options.TargetDirAnnotation => true
-      case _ => false
-    }
+    val annos = Driver.filterAnnotations(firrtl.Driver.getAnnotations(optionsManager))
     optionsManager.firrtlOptions = optionsManager.firrtlOptions.copy(annotations = annos.toList)
     chisel3.Driver.execute(optionsManager, dutGen) match {
       case ChiselExecutionSuccess(Some(circuit), _, Some(firrtlExecutionResult)) =>

--- a/src/main/scala/chisel3/iotesters/TreadleBackend.scala
+++ b/src/main/scala/chisel3/iotesters/TreadleBackend.scala
@@ -128,10 +128,7 @@ private[iotesters] object setupTreadleBackend {
     optionsManager.firrtlOptions = optionsManager.firrtlOptions.copy(compilerName = "low")
     // Workaround to propagate Annotations generated from command-line options to second Firrtl
     // invocation, run after updating compilerName so we only get one emitCircuit annotation
-    val annos = firrtl.Driver.getAnnotations(optionsManager).filterNot {
-      case _: firrtl.options.TargetDirAnnotation => true
-      case _ => false
-    }
+    val annos = Driver.filterAnnotations(firrtl.Driver.getAnnotations(optionsManager))
     optionsManager.firrtlOptions = optionsManager.firrtlOptions.copy(annotations = annos.toList)
 
     // generate VcdOutput overrides setting of writeVcd


### PR DESCRIPTION
`logger.LogLevelAnnotation` and `firrtl.stage.FirrtlCircuitAnnotation`

(without this, chisel-tutorial fails to run tests successfully)