### PR TITLE
Quick fix (hack) for Stage/Phase CircuitForm issues.

### DIFF
--- a/src/main/scala/chisel3/iotesters/TreadleBackend.scala
+++ b/src/main/scala/chisel3/iotesters/TreadleBackend.scala
@@ -2,10 +2,10 @@
 
 package chisel3.iotesters
 
-import chisel3.{Element, ChiselExecutionSuccess, Mem, assert}
+import chisel3.{ChiselExecutionSuccess, Element, Mem, assert}
 import chisel3.experimental.MultiIOModule
 import chisel3.internal.InstanceId
-import firrtl.{FirrtlExecutionFailure, FirrtlExecutionSuccess}
+import firrtl.{FirrtlExecutionFailure, FirrtlExecutionSuccess, LowForm}
 import treadle.TreadleTester
 
 private[iotesters] class TreadleBackend(
@@ -15,7 +15,7 @@ private[iotesters] class TreadleBackend(
 )
 extends Backend(_seed = System.currentTimeMillis()) {
 
-  val treadleTester = new TreadleTester(firrtlIR, optionsManager)
+  val treadleTester = new TreadleTester(firrtlIR, optionsManager, LowForm)
   reset(5) // reset firrtl treadle on construction
 
   private val portNames = dut.getPorts.flatMap { case chisel3.internal.firrtl.Port(id, dir) =>


### PR DESCRIPTION
Provide the optional CircuitForm argument to the TreadleTester constructor to indicate it shouldn't run the chirrtl to FIRRTL transforms since we're already in low FIRRTL.