### PR TITLE
Support for FST traces in verilator backend

### DIFF
--- a/src/main/scala/chisel3/iotesters/TesterOptions.scala
+++ b/src/main/scala/chisel3/iotesters/TesterOptions.scala
@@ -12,24 +12,25 @@ import treadle.HasTreadleSuite
 import scala.util.matching.Regex
 
 case class TesterOptions(
-  isGenVerilog:         Boolean = false,
-  isGenHarness:         Boolean = false,
-  isCompiling:          Boolean = false,
-  isRunTest:            Boolean = false,
-  isVerbose:            Boolean = false,
-  displayBase:          Int     = 10,
-  testerSeed:           Long    = System.currentTimeMillis,
-  testCmd:              Seq[String] = Seq.empty,
-  moreVcsFlags:         Seq[String] = Seq.empty,
-  moreVcsCFlags:        Seq[String] = Seq.empty,
-  vcsCommandEdits:      String = "",
-  backendName:          String  = "treadle",
-  logFileName:          String  = "",
-  waveform:             Option[File] = None,
-  moreIvlFlags:         Seq[String] = Seq.empty,
-  moreIvlCFlags:        Seq[String] = Seq.empty,
-  ivlCommandEdits:      String = "",
-  generateVcdOutput:    String = ""
+                          isGenVerilog:         Boolean = false,
+                          isGenHarness:         Boolean = false,
+                          isCompiling:          Boolean = false,
+                          isRunTest:            Boolean = false,
+                          isVerbose:            Boolean = false,
+                          displayBase:          Int     = 10,
+                          testerSeed:           Long    = System.currentTimeMillis,
+                          testCmd:              Seq[String] = Seq.empty,
+                          moreVcsFlags:         Seq[String] = Seq.empty,
+                          moreVcsCFlags:        Seq[String] = Seq.empty,
+                          vcsCommandEdits:      String = "",
+                          backendName:          String  = "treadle",
+                          logFileName:          String  = "",
+                          waveform:             Option[File] = None,
+                          moreIvlFlags:         Seq[String] = Seq.empty,
+                          moreIvlCFlags:        Seq[String] = Seq.empty,
+                          ivlCommandEdits:      String = "",
+                          generateVcdOutput:    String = "",
+                          verilatorFstTrace:    Boolean = true
 ) extends ComposableOptions
 
 object TesterOptions {


### PR DESCRIPTION
Introducing the ability to use FST format as the output format of `Verilator` trace dump, instead of the VCD format. FST is a more efficient trace format introduced by the `gtkwave` project.
A boolean option named `verilatorFstTrace` is currently added to `TesterOptions`, but can be eventually ported into `chisel-testers2` with an appropriate Annotation.