### PR TITLE
Be explicit about scala.io

### DIFF
--- a/src/main/scala/chisel3/iotesters/ChiselMain.scala
+++ b/src/main/scala/chisel3/iotesters/ChiselMain.scala
@@ -9,6 +9,8 @@ import scala.util.DynamicVariable
 
 import chisel3._
 
+import firrtl.FileUtils
+
 private[iotesters] class TesterContext {
   var isGenVerilog = false
   var isGenHarness = false
@@ -125,7 +127,7 @@ object chiselMain {
         writer.write(compileResult.getEmittedCircuit.value)
         writer.close()
       case _ =>
-    } 
+    }
 
     if (context.isGenHarness) genHarness(dut, nodes, chirrtl)
 
@@ -156,7 +158,7 @@ object chiselMain {
     context.backend = Some(context.backendType match {
       case "firrtl" =>
         val file = new java.io.File(context.targetDir, s"${dut.name}.ir")
-        val ir = io.Source.fromFile(file).getLines mkString "\n"
+        val ir = FileUtils.getText(file)
         new FirrtlTerpBackend(dut, ir)
       case "verilator" =>
         new VerilatorBackend(dut, context.testCmd.toList, context.testerSeed)


### PR DESCRIPTION
This fixes a bug when trying to build unidoc of chisel3 and
chisel-testers for the website. I'm not 100% sure of the interaction,
but additional plugins/libraries may use the package "io" and cause an
error when building here.

E.g., this avoids nonsense like the following:
```
[error] /home/se/repos/github.com/freechipsproject/www.chisel-lang.org/chisel-testers/src/main/scala/chisel3/iotesters/ChiselMain.scala:159:21: object Source is not a member of package io
[error]         val ir = io.Source.fromFile(file).getLines mkString "\n"
[error]                     ^
```
