### PR TITLE
Refactor chisel main

### DIFF
--- a/src/main/scala/chisel3/iotesters/AdvTester.scala
+++ b/src/main/scala/chisel3/iotesters/AdvTester.scala
@@ -22,7 +22,7 @@ trait AdvTests extends PeekPokeTests {
 
 abstract class AdvTester[+T <: Module](dut: T,
                                        base: Int = 16,
-                                       logFile: Option[java.io.File] = chiselMain.context.logFile)
+                                       logFile: Option[java.io.File] = None)
                 extends PeekPokeTester(dut, base, logFile) {
   val defaultMaxCycles = 1024L
   var _cycles = 0L

--- a/src/main/scala/chisel3/iotesters/Backends.scala
+++ b/src/main/scala/chisel3/iotesters/Backends.scala
@@ -2,7 +2,8 @@
 package chisel3.iotesters
 
 import chisel3.internal.InstanceId
-import java.io.PrintStream
+import chisel3.experimental.MultiIOModule
+import chisel3.internal.firrtl.Circuit
 
 /**
   * define interface for ClassicTester backend implementations such as verilator and firrtl interpreter
@@ -10,6 +11,20 @@ import java.io.PrintStream
 
 private[iotesters] abstract class Backend(private[iotesters] val _seed: Long = System.currentTimeMillis) {
   val rnd = new scala.util.Random(_seed)
+
+  // Prepare the backend to (potentially generate and) run the simulation
+  def prep[T <: MultiIOModule](
+              dut: T,
+              firrtlIR: Option[String] = None,
+              circuitOption: Option[Circuit] = None,
+              optionsManager: TesterOptionsManager = new TesterOptionsManager): Unit
+  def dut: MultiIOModule
+  // Generate the simulation harness (if required)
+  def genHarness(): Unit = {}
+  // Build the simulation
+  def build(): Unit = {}
+  // Run the simulation
+  def run(cmd: Option[Seq[String]] = None): Unit
 
   def poke(signal: InstanceId, value: BigInt, off: Option[Int])
           (implicit logger: TestErrorLog, verbose: Boolean, base: Int): Unit

--- a/src/main/scala/chisel3/iotesters/Driver.scala
+++ b/src/main/scala/chisel3/iotesters/Driver.scala
@@ -243,7 +243,10 @@ object Driver {
                       (testerGen: T => PeekPokeTester[T]): Boolean = {
     val circuit = chisel3.Driver.elaborate(dutGen)
     val dut = getTopModule(circuit).asInstanceOf[T]
-    backendVar.withValue(Some(new VerilatorBackend(dut, cmd))) {
+    backendVar.withValue(Some(new VerilatorBackend())) {
+      val b = backend.get
+      b.prep(dut, None, None)
+      b.run(Some(cmd))
       try {
         testerGen(dut).finish
       } catch { case e: Throwable =>

--- a/src/main/scala/chisel3/iotesters/PeekPokeTesterUtils.scala
+++ b/src/main/scala/chisel3/iotesters/PeekPokeTesterUtils.scala
@@ -228,7 +228,7 @@ private[iotesters] object verilogToIVL extends EditableBuildCSimulatorCommand {
                                 ): String = {
 
     val (cFlags, cCFlags, cLFlags) = composeFlags(topModule, dir,
-      iFlags ++ blackBoxVerilogList(dir) ++ Seq("-o", s"${dir.toString}/$topModule", s"${dir.toString}/$topModule.v", harness.toString),
+      iFlags ++ blackBoxVerilogList(dir) ++ Seq("-o", s"${dir.toString}/$topModule", s"${dir.toString}/$topModule.v", harness.getAbsolutePath),
       iCFlags
     )
 
@@ -297,7 +297,7 @@ private[iotesters] object verilogToVCS extends EditableBuildCSimulatorCommand {
                                 ): String = {
 
     val (cFlags, cCFlags, _) = composeFlags(topModule, dir,
-      iFlags ++ blackBoxVerilogList(dir) ++ Seq("-o", topModule, s"$topModule.v", harness.toString, "vpi.cpp"),
+      iFlags ++ blackBoxVerilogList(dir) ++ Seq("-o", topModule, s"$topModule.v", harness.getAbsolutePath, "vpi.cpp"),
       iCFlags
     )
 

--- a/src/main/scala/chisel3/iotesters/PeekPokeTesterUtils.scala
+++ b/src/main/scala/chisel3/iotesters/PeekPokeTesterUtils.scala
@@ -205,7 +205,6 @@ private[iotesters] object verilogToIVL extends EditableBuildCSimulatorCommand {
       s"-o $topModule.vpi",
       "-D__ICARUS__",
       "-I$IVL_HOME",
-      s"-I$dir",
       "-fPIC",
       "-std=c++11",
       "-shared"

--- a/src/main/scala/chisel3/iotesters/PeekPokeTesterUtils.scala
+++ b/src/main/scala/chisel3/iotesters/PeekPokeTesterUtils.scala
@@ -12,6 +12,7 @@ import chisel3.internal.firrtl.Circuit
 
 import scala.sys.process._
 import scala.collection.mutable.ArrayBuffer
+import scala.collection.JavaConversions._
 
 // TODO: FIRRTL will eventually return valid names
 private[iotesters] object validName {
@@ -241,6 +242,10 @@ private[iotesters] object verilogToIVL extends EditableBuildCSimulatorCommand {
     moreIvlFlags: Seq[String] = Seq.empty[String],
     moreIvlCFlags: Seq[String] = Seq.empty[String],
     editCommands: String = ""): ProcessBuilder = {
+    val environmentVariables = System.getenv()
+    for ( key <- List("IVL_HOME", "IVL_LIB")) {
+      require(environmentVariables.containsKey(key), s" $key isn't defined in the environment")
+    }
 
     val finalCommand = editCSimulatorCommand(constructCSimulatorCommand(topModule, dir, ivlHarness, moreIvlFlags, moreIvlCFlags), editCommands)
     println(s"$finalCommand")

--- a/src/main/scala/chisel3/iotesters/TesterOptions.scala
+++ b/src/main/scala/chisel3/iotesters/TesterOptions.scala
@@ -15,7 +15,7 @@ case class TesterOptions(
   isGenVerilog:         Boolean = false,
   isGenHarness:         Boolean = false,
   isCompiling:          Boolean = false,
-  isRunTest:            Boolean = false,
+  isRunTest:            Boolean = true,
   isVerbose:            Boolean = false,
   displayBase:          Int     = 10,
   testerSeed:           Long    = System.currentTimeMillis,

--- a/src/test/scala/chisel3/iotesters/DriverSpec.scala
+++ b/src/test/scala/chisel3/iotesters/DriverSpec.scala
@@ -118,21 +118,21 @@ class DriverSpec extends FreeSpec with Matchers {
       chiselMain(args, () => new DriverTest, (c: DriverTest) => new DriverTestTester(c))
     }
     "--v --logfile chiselMain.log --backend treadle" in {
-      val args = Array("--v", "--logFile", "chiselMain.log", "--backend", "treadle")
+      val args = Array("--v", "--logFile", "chiselMain-treadle.log", "--backend", "treadle")
       chiselMain(args, () => new DriverTest, (c: DriverTest) => new DriverTestTester(c))
     }
     "--v --logfile chiselMain.log --backend verilator" in {
-      val args = Array("--v", "--logFile", "chiselMain.log", "--backend", "verilator")
+      val args = Array("--v", "--logFile", "chiselMain-verilator.log", "--backend", "verilator")
       chiselMain(args, () => new DriverTest, (c: DriverTest) => new DriverTestTester(c))
     }
     "--v --logfile chiselMain.log --backend vcs" in {
       assume(firrtl.FileUtils.isVCSAvailable)
-      val args = Array("--v", "--logFile", "chiselMain.log", "--backend", "vcs")
+      val args = Array("--v", "--logFile", "chiselMain-vcs.log", "--backend", "vcs")
       chiselMain(args, () => new DriverTest, (c: DriverTest) => new DriverTestTester(c))
     }
     "--v --logfile chiselMain.log --test --backend ivl" in {
       assume(firrtl.FileUtils.isCommandAvailable(Seq("iverilog", "-V")))
-      val args = Array("--v", "--logFile", "chiselMain.log", "--test", "--backend", "ivl")
+      val args = Array("--v", "--logFile", "chiselMain-iverilog.log", "--test", "--backend", "ivl")
       chiselMain(args, () => new DriverTest, (c: DriverTest) => new DriverTestTester(c))
     }
     "--v --logfile chiselMain.log --backend foo" in {

--- a/src/test/scala/chisel3/iotesters/DriverSpec.scala
+++ b/src/test/scala/chisel3/iotesters/DriverSpec.scala
@@ -104,4 +104,51 @@ class DriverSpec extends FreeSpec with Matchers {
       deleteDirectoryHierarchy(new File("foo2"))
     }
   }
+  "chiselMain should work with a variety of command line arguments" - {
+    "--v --logfile chiselMain.log --compile --genHarness --test --backend verilator" in {
+      val args = Array("--v", "--logFile", "chiselMain.log", "--compile", "--genHarness", "--test",
+        "--backend",
+        "verilator")
+      chiselMain(args, () => new DriverTest, (c: DriverTest) => new DriverTestTester(c))
+    }
+    "--v --logfile chiselMain.log --compile --genHarness --test --backend treadle" in {
+      val args = Array("--v", "--logFile", "chiselMain.log", "--compile", "--genHarness", "--test",
+        "--backend",
+        "treadle")
+      chiselMain(args, () => new DriverTest, (c: DriverTest) => new DriverTestTester(c))
+    }
+    "--v --logfile chiselMain.log --backend treadle" in {
+      val args = Array("--v", "--logFile", "chiselMain.log", "--backend", "treadle")
+      chiselMain(args, () => new DriverTest, (c: DriverTest) => new DriverTestTester(c))
+    }
+    "--v --logfile chiselMain.log --backend verilator" in {
+      val args = Array("--v", "--logFile", "chiselMain.log", "--backend", "verilator")
+      chiselMain(args, () => new DriverTest, (c: DriverTest) => new DriverTestTester(c))
+    }
+    "--v --logfile chiselMain.log --backend vcs" in {
+      assume(firrtl.FileUtils.isVCSAvailable)
+      val args = Array("--v", "--logFile", "chiselMain.log", "--backend", "vcs")
+      chiselMain(args, () => new DriverTest, (c: DriverTest) => new DriverTestTester(c))
+    }
+    "--v --logfile chiselMain.log --test --backend ivl" in {
+      assume(firrtl.FileUtils.isCommandAvailable(Seq("iverilog", "-V")))
+      val args = Array("--v", "--logFile", "chiselMain.log", "--test", "--backend", "ivl")
+      chiselMain(args, () => new DriverTest, (c: DriverTest) => new DriverTestTester(c))
+    }
+    "--v --logfile chiselMain.log --backend foo" in {
+      val caught = intercept[BackendException] {
+        val args = Array("--v", "--logFile", "chiselMain.log", "--backend", "foo")
+        chiselMain(args, () => new DriverTest, (c: DriverTest) => new DriverTestTester(c))
+      }
+      assert(caught.getMessage.contains("Unknown backend: foo"))
+    }
+  }
+  "chiselMainTest should work with a variety of command line arguments" - {
+    "--v --logfile chiselMain.log" in {
+      val args = Array("--v", "--logFile", "chiselMain.log", "--compile", "--genHarness", "--test",
+        "--backend",
+        "verilator")
+      chiselMainTest(args, () => new DriverTest)((c: DriverTest) => new DriverTestTester(c))
+    }
+  }
 }

--- a/src/test/scala/chisel3/iotesters/ToolChainSpec.scala
+++ b/src/test/scala/chisel3/iotesters/ToolChainSpec.scala
@@ -87,7 +87,7 @@ class ToolChainSpec extends FreeSpec with Matchers {
     s"Ability to edit vcs command line - $builderName" - {
       // Build the expected command (default arguments)
       val expectedCommand = builder.constructCSimulatorCommand(dummyTop, dummyDir, dummyHarness)
-      val expectedMultipleEditVCSCommand = """cd dir && vcs -full64 -loud -timescale=1ns/1ps -debug_pp -Mdir=top.csrc +vcs+lic+wait +vcs+initreg+random +define+CLOCK_PERIOD=1 -P vpi.tab -cpp g++ -O2 -LDFLAGS -lstdc++ -CFLAGS "-I$VCS_HOME/include -I$dir -fPIC -std=c++11" -o top top.v harness.v vpi.cpp"""
+      val expectedMultipleEditVCSCommand = s"""cd dir && vcs -full64 -loud -timescale=1ns/1ps -debug_pp -Mdir=top.csrc +vcs+lic+wait +vcs+initreg+random +define+CLOCK_PERIOD=1 -P vpi.tab -cpp g++ -O2 -LDFLAGS -lstdc++ -CFLAGS "-I$$VCS_HOME/include -I$$dir -fPIC -std=c++11" -o top top.v ${dummyHarness.getAbsolutePath} vpi.cpp"""
 
       "can be done from a single edit on command line" in {
         val dummyArg = "-A-dummy-arg"

--- a/src/test/scala/chisel3/iotesters/ToolChainSpec.scala
+++ b/src/test/scala/chisel3/iotesters/ToolChainSpec.scala
@@ -52,7 +52,7 @@ class ToolChainSpec extends FreeSpec with Matchers {
 
         gFlags.length should be (2)
 
-        val (vcsFlags, vcsCFlags) = builder.composeFlags(dummyTop, dummyDir, gFlags, cFlags)
+        val (vcsFlags, vcsCFlags, _) = builder.composeFlags(dummyTop, dummyDir, gFlags, cFlags)
 
         vcsFlags.contains(flag1) should be (true)
         vcsFlags.contains(flag2) should be (true)
@@ -76,7 +76,7 @@ class ToolChainSpec extends FreeSpec with Matchers {
         }
         cFlags.length should be (2)
 
-        val (vcsFlags, vcsCFlags) = builder.composeFlags(
+        val (vcsFlags, vcsCFlags, _) = builder.composeFlags(
           dummyTop, dummyDir, gFlags, cFlags)
 
         vcsCFlags.contains(cFlag1) should be (true)

--- a/src/test/scala/verilator/Verilator.scala
+++ b/src/test/scala/verilator/Verilator.scala
@@ -22,7 +22,7 @@ class VerilatorTest extends FlatSpec with Matchers {
       chiselMain(args, () => new doohickey())
     }
   it should "be able to deal with zero-width wires" in {
-      chisel3.iotesters.Driver.execute(Array("--backend-name", "verilator"), () => new ZeroWidthIOModule) {
+      chisel3.iotesters.Driver.execute(Array("--backend-name", "verilator", "--targetDir", targetDir.getPath), () => new ZeroWidthIOModule) {
           c => new ZeroWidthIOTester(c)
     }
   }


### PR DESCRIPTION
Reduce code duplication and subtle differences between backends.
Default `isRunTest` to true for TesterOptions.
Default `logFile` to `None` for `AdvTester`.
Replace `logFile` and `waveform` with `String` names instead of `File` objects.