### PR TITLE
This allows the PeekPokeTester to us peekAt and pokeAt with SyncReadMem

### DIFF
--- a/src/main/scala/chisel3/iotesters/PeekPokeTester.scala
+++ b/src/main/scala/chisel3/iotesters/PeekPokeTester.scala
@@ -230,7 +230,7 @@ abstract class PeekPokeTester[+T <: MultiIOModule](
     }
   }
 
-  def pokeAt[TT <: Element: Pokeable](data: Mem[TT], value: BigInt, off: Int): Unit = {
+  def pokeAt[TT <: Element: Pokeable](data: MemBase[TT], value: BigInt, off: Int): Unit = {
     backend.poke(data, value, Some(off))
   }
 
@@ -293,7 +293,7 @@ abstract class PeekPokeTester[+T <: MultiIOModule](
     bigIntMap
   }
 
-  def peekAt[TT <: Element: Pokeable](data: Mem[TT], off: Int): BigInt = {
+  def peekAt[TT <: Element: Pokeable](data: MemBase[TT], off: Int): BigInt = {
     backend.peek(data, Some(off))
   }
 

--- a/src/main/scala/chisel3/iotesters/TreadleBackend.scala
+++ b/src/main/scala/chisel3/iotesters/TreadleBackend.scala
@@ -2,7 +2,7 @@
 
 package chisel3.iotesters
 
-import chisel3.{ChiselExecutionSuccess, Element, Mem, MultiIOModule, assert}
+import chisel3.{ChiselExecutionSuccess, Element, Mem, MemBase, MultiIOModule, SyncReadMem, assert}
 import chisel3.internal.InstanceId
 import firrtl.{FirrtlExecutionFailure, FirrtlExecutionSuccess, LowForm}
 import treadle.TreadleTester
@@ -30,7 +30,7 @@ extends Backend(_seed = System.currentTimeMillis()) {
         treadleTester.poke(name, value)
         if (verbose) logger info s"  POKE $name <- ${bigIntToStr(value, base)}"
 
-      case mem: Mem[_] =>
+      case mem: MemBase[_] =>
         val memoryName = mem.pathName.split("""\.""").tail.mkString(".")
         treadleTester.pokeMemory(memoryName, off.getOrElse(0), value)
         if (verbose) logger info s"  POKE MEMORY $memoryName <- ${bigIntToStr(value, base)}"
@@ -53,7 +53,7 @@ extends Backend(_seed = System.currentTimeMillis()) {
         if (verbose) logger info s"  PEEK $name -> ${bigIntToStr(result, base)}"
         result
 
-      case mem: Mem[_] =>
+      case mem: MemBase[_] =>
         val memoryName = mem.pathName.split("""\.""").tail.mkString(".")
 
         treadleTester.peekMemory(memoryName, off.getOrElse(0))

--- a/src/test/scala/examples/SyncReadMemTest.scala
+++ b/src/test/scala/examples/SyncReadMemTest.scala
@@ -1,0 +1,66 @@
+// See README.md for license details.
+
+package examples
+
+import org.scalatest.{FreeSpec, Matchers}
+import chisel3._
+import chisel3.iotesters.PeekPokeTester
+import logger.LazyLogging
+
+class HasSyncReadMem extends MultiIOModule {
+  val readAddr  = IO(Input(UInt(16.W)))
+  val readData  = IO(Output(UInt(16.W)))
+  val writeAddr = IO(Input(UInt(16.W)))
+  val writeData = IO(Input(UInt(16.W)))
+  val writeEnable = IO(Input(Bool()))
+
+  val mem = SyncReadMem(10, UInt(16.W))
+
+  readData := mem(readAddr)
+  when(writeEnable) {
+    mem(writeAddr) := writeData
+  }
+}
+
+class SyncReadMemTest extends FreeSpec with Matchers {
+  "peekAt and pokeAt should work with treadle" in {
+    iotesters.Driver.execute(
+      Array(
+        "--backend-name",
+        "treadle",
+        "--target-dir",
+        "test_run_dir/sync_read_mem_test_treadle",
+        "--top-name",
+        "SyncReadMem",
+      ),
+      () => new HasSyncReadMem
+    ) { c =>
+      new PeekPokeTester(c) {
+        poke(c.writeEnable, 1)
+        for (i <- 0 until 8) {
+          poke(c.writeAddr, i)
+          poke(c.writeData, i + 30)
+          step(1)
+        }
+        poke(c.writeEnable, 0)
+        for (i <- 0 until 8) {
+          poke(c.readAddr, i)
+          step(1)
+          val memValue = peek(c.readData)
+          memValue should be(i + 30)
+          logger.info(s"$i -> $memValue")
+        }
+        for (i <- 0 until 8) {
+          pokeAt(c.mem, i + 20, i)
+        }
+        step(1)
+        for (i <- 0 until 8) {
+          val memValue = peekAt(c.mem, i)
+          logger.info(s"$i -> $memValue")
+          memValue should be(i + 20)
+
+        }
+      }
+    } should be(true)
+  }
+}


### PR DESCRIPTION
- Prior to this, it could be done with Mem but not SyncReadMemTest
- Changed peekAt and pokeAt to use MemBase as the type
- Added peek and poke in TreadleBackend to use MemBase