### PR TITLE
Add VSIM backend (Modelsim, Questasim)

### DIFF
--- a/src/main/resources/sim_api.h
+++ b/src/main/resources/sim_api.h
@@ -16,6 +16,8 @@
 #include <unistd.h>
 #include <sys/mman.h>
 #include <time.h>
+#include <limits.h>
+#include <string>
 
 enum SIM_CMD { RESET, STEP, UPDATE, POKE, PEEK, FORCE, GETID, GETCHK, FIN };
 const int SIM_CMD_MAX_BYTES = 1024;
@@ -125,10 +127,17 @@ public:
   }
   void init_channels() {
     pid_t pid = getpid();
+    char cwd[PATH_MAX];
+    if (getcwd(cwd, sizeof(cwd)) != NULL) {
+       printf("Current working dir: %s\n", cwd);
+    } else {
+       perror("getcwd() error");
+       return;
+    }
     std::ostringstream in_ch_name, out_ch_name, cmd_ch_name;
-    in_ch_name  << std::dec << std::setw(8) << std::setfill('0') << pid << ".in";
-    out_ch_name << std::dec << std::setw(8) << std::setfill('0') << pid << ".out";
-    cmd_ch_name << std::dec << std::setw(8) << std::setfill('0') << pid << ".cmd";
+    in_ch_name  << cwd << "/" << std::dec << std::setw(8) << std::setfill('0') << pid << ".in";
+    out_ch_name << cwd << "/" << std::dec << std::setw(8) << std::setfill('0') << pid << ".out";
+    cmd_ch_name << cwd << "/" << std::dec << std::setw(8) << std::setfill('0') << pid << ".cmd";
     size_t input_size = this->sim_data.storage_size(this->sim_data.inputs);
     in_channel  = new channel_t(in_ch_name.str(), input_size);
     size_t output_size = this->sim_data.storage_size(this->sim_data.outputs);

--- a/src/main/resources/sim_api.h
+++ b/src/main/resources/sim_api.h
@@ -17,7 +17,7 @@
 #include <sys/mman.h>
 #include <time.h>
 #include <limits.h>
-#include <string>
+#include <cstring>
 
 enum SIM_CMD { RESET, STEP, UPDATE, POKE, PEEK, FORCE, GETID, GETCHK, FIN };
 const int SIM_CMD_MAX_BYTES = 1024;
@@ -127,17 +127,21 @@ public:
   }
   void init_channels() {
     pid_t pid = getpid();
-    char cwd[PATH_MAX];
-    if (getcwd(cwd, sizeof(cwd)) != NULL) {
-       printf("Current working dir: %s\n", cwd);
-    } else {
+#ifdef __VSIM__
+    // As VSIM relative path management is a mess, enforce the use of absolute paths for all channels
+    char cwd[PATH_MAX+1];
+    if (getcwd(cwd, sizeof(cwd)) == NULL) {
        perror("getcwd() error");
        return;
     }
+    strncat(cwd, "/", 1);
+#else
+    char cwd[] = "";
+#endif
     std::ostringstream in_ch_name, out_ch_name, cmd_ch_name;
-    in_ch_name  << cwd << "/" << std::dec << std::setw(8) << std::setfill('0') << pid << ".in";
-    out_ch_name << cwd << "/" << std::dec << std::setw(8) << std::setfill('0') << pid << ".out";
-    cmd_ch_name << cwd << "/" << std::dec << std::setw(8) << std::setfill('0') << pid << ".cmd";
+    in_ch_name  << cwd << std::dec << std::setw(8) << std::setfill('0') << pid << ".in";
+    out_ch_name << cwd << std::dec << std::setw(8) << std::setfill('0') << pid << ".out";
+    cmd_ch_name << cwd << std::dec << std::setw(8) << std::setfill('0') << pid << ".cmd";
     size_t input_size = this->sim_data.storage_size(this->sim_data.inputs);
     in_channel  = new channel_t(in_ch_name.str(), input_size);
     size_t output_size = this->sim_data.storage_size(this->sim_data.outputs);

--- a/src/main/resources/utils.fdo
+++ b/src/main/resources/utils.fdo
@@ -1,0 +1,61 @@
+proc str_count {char str} {
+    set count 0
+    set index 0
+    while {$index > -1} {
+        set index [string first $char $str $index]
+        if {$index > -1} {
+            incr count
+            incr index
+        }
+    }
+    return $count
+}
+
+proc add_wave {args} {
+    # same as add wave but excluding all signal prefixed with _
+    # restricted to arguments of [find] with addition of -depth N and -r
+    # search pattern must be last argument
+    set arglen [llength $args]
+    set findargs [list]
+    set depth 0
+    set index 0
+    while {$index < $arglen} {
+        set arg [lindex $args $index]
+        switch -exact -- $arg {
+            -depth {
+                set depth [lindex $args [incr index]]
+            }
+            -r {
+                # improve compliance with add wave arguments
+                lappend findargs "-recursive"
+            }
+            default {
+                lappend findargs $arg
+            }
+        }
+        incr index
+    }
+    set pattern [lindex $findargs [expr [llength $findargs]-1]]
+    puts "NOTE: add_wave search pattern: $pattern"
+    set pattern_start_depth [str_count "/" $pattern]
+    # note : string compare return 0 for match, -1 otherwise
+    if {[string compare "/" [string index $pattern 0]]} {
+      incr pattern_start_depth
+    }
+    set threshold [expr $pattern_start_depth+$depth]
+    puts "NOTE: max absolute depth: $threshold"
+    set excluded [find signal -recursive _*]
+    # build dict for faster lookups
+    set ex [dict create]
+    foreach elt $excluded {
+      dict set ex $elt ""
+    }
+    set matching [lsort [find signal {*}$findargs]]
+    foreach elt $matching {
+      if {![dict exists $ex $elt] && [str_count "/" $elt] <= $threshold} {
+        if {[string compare "#" [string index $elt 1]]} {
+          add wave $elt
+        }
+      }
+    }
+}

--- a/src/main/resources/vpi.cpp
+++ b/src/main/resources/vpi.cpp
@@ -57,7 +57,13 @@ PLI_INT32 sim_start_cb(p_cb_data cb_data) {
 
 PLI_INT32 sim_end_cb(p_cb_data cb_data) {
   delete vpi_api;
-  vpi_control(vpiFinish, 0);
+#ifndef __VSIM__
+  // I guess this line should be removed for all backends since cbEndOfSimulation is triggered on vpi_control(vpiFinish, 0); (hence looping forever)
+  vpi_control(vpiFinish, 0); 
+# else 
+  // double vpiFinish makes vsim segfault => it doesn't handle this infinite callback loop properly
+  // vpi_control(vpiStop, 0); // this is harmless but useless ...
+#endif
   return 0;
 }
 

--- a/src/main/resources/vpi.h
+++ b/src/main/resources/vpi.h
@@ -143,7 +143,12 @@ private:
   }
 
   virtual void finish() {
+#ifndef __VSIM__
     vpi_control(vpiFinish, 0);
+# else 
+  // vpiFinish makes vsim quit gui which is not convenient for waves 
+  vpi_control(vpiStop, 0);
+#endif
   }
 
   virtual void step() { }

--- a/src/main/scala/chisel3/iotesters/ChiselMain.scala
+++ b/src/main/scala/chisel3/iotesters/ChiselMain.scala
@@ -33,6 +33,7 @@ object chiselMain {
     case "--firrtl" :: tail => context.backendType = "firrtl" ; parseArgs(tail)
     case "--verilator" :: tail => context.backendType = "verilator" ; parseArgs(tail)
     case "--vcs" :: tail => context.backendType = "vcs" ; parseArgs(tail)
+    case "--vsim" :: tail => context.backendType = "vsim" ; parseArgs(tail)
     case "--glsim" :: tail => context.backendType = "glsim" ; parseArgs(tail)
     case "--v" :: tail  => context.isGenVerilog = true ; parseArgs(tail)
     case "--backend" :: value :: tail => context.backendType = value ; parseArgs(tail)
@@ -62,6 +63,9 @@ object chiselMain {
         val harness = new FileWriter(new File(dir, s"${chirrtl.main}-harness.v"))
         val waveform = new File(dir, s"${chirrtl.main}.vcd").toString
         genIVLVerilogHarness(dut, harness, waveform.toString)
+      case "vsim" =>
+        val harness = new FileWriter(new File(dir, s"${chirrtl.main}-harness.v"))
+        genVSIMVerilogHarness(dut, harness)
       case "vcs" | "glsim" =>
         val harness = new FileWriter(new File(dir, s"${chirrtl.main}-harness.v"))
         val waveform = new File(dir, s"${chirrtl.main}.vpd").toString
@@ -144,7 +148,7 @@ object chiselMain {
         case "firrtl" => // skip
         case "verilator" =>
           context.testCmd += new File(context.targetDir, s"V$name").toString
-        case "vcs" | "glsim" =>
+        case "vcs" | "glsim" | "vsim" =>
           context.testCmd += new File(context.targetDir, name).toString
         case b => throw BackendException(b)
       }
@@ -164,6 +168,8 @@ object chiselMain {
         new VerilatorBackend(dut, context.testCmd.toList, context.testerSeed)
       case "vcs" | "glsim" =>
         new VCSBackend(dut, context.testCmd.toList, context.testerSeed)
+      case "vsim" =>
+        new VSIMBackend(dut, context.testCmd.toList, context.testerSeed)
       case b => throw BackendException(b)
     })
   }

--- a/src/main/scala/chisel3/iotesters/ChiselPokeSpec.scala
+++ b/src/main/scala/chisel3/iotesters/ChiselPokeSpec.scala
@@ -30,6 +30,11 @@ case object VcsBackend extends TesterBackend {
     setupVCSBackend(dutGen, options)
   }
 }
+case object VsimBackend extends TesterBackend {
+  override def create[T <: Module](dutGen: () => T, options: TesterOptionsManager): (T, Backend) = {
+    setupVSIMBackend(dutGen, options)
+  }
+}
 
 trait ChiselPokeTesterUtils extends Assertions {
   class InnerTester(val backend: Backend, val options: TesterOptionsManager) {

--- a/src/main/scala/chisel3/iotesters/Driver.scala
+++ b/src/main/scala/chisel3/iotesters/Driver.scala
@@ -57,6 +57,8 @@ object Driver {
             setupIVLBackend(dutGenerator, optionsManager)
           case "vcs" =>
             setupVCSBackend(dutGenerator, optionsManager)
+          case "vsim" =>
+            setupVSIMBackend(dutGenerator, optionsManager)
           case _ =>
             throw new Exception(s"Unrecognized backend name ${testerOptions.backendName}")
         }
@@ -70,6 +72,7 @@ object Driver {
               backend match {
                 case b: IVLBackend => TesterProcess.kill(b)
                 case b: VCSBackend => TesterProcess.kill(b)
+                case b: VSIMBackend => TesterProcess.kill(b)
                 case b: VerilatorBackend => TesterProcess.kill(b)
                 case _ =>
               }
@@ -214,6 +217,7 @@ object Driver {
     *                    "verilator" will use the verilator c++ simulation generator
     *                    "ivl" will use the Icarus Verilog simulation
     *                    "vcs" will use the VCS simulation
+    *                    "vsim" will use the ModelSim/QuestaSim simulation
     * @param verbose     Setting this to true will make the tester display information on peeks,
     *                    pokes, steps, and expects.  By default only failed expects will be printed
     * @param testerSeed  Set the random number generator seed
@@ -251,6 +255,8 @@ object Driver {
           case Some(b: IVLBackend) =>
             TesterProcess kill b
           case Some(b: VCSBackend) =>
+            TesterProcess kill b
+          case Some(b: VSIMBackend) =>
             TesterProcess kill b
           case Some(b: VerilatorBackend) =>
             TesterProcess kill b

--- a/src/main/scala/chisel3/iotesters/PeekPokeTesterUtils.scala
+++ b/src/main/scala/chisel3/iotesters/PeekPokeTesterUtils.scala
@@ -240,6 +240,102 @@ private[iotesters] object verilogToIVL extends EditableBuildCSimulatorCommand {
   }
 }
 
+private[iotesters] object verilogToVSIM extends EditableBuildCSimulatorCommand {
+  val prefix = "vsim-command-edit"
+  def composeCommand(
+                      topModule: String,
+                      dir: java.io.File,
+                      vlogFlags: Seq[String],
+                      cFlags: Seq[String]
+                    ): String = {
+    Seq("cd", dir.toString, "&&") ++
+      Seq("g++") ++ cFlags ++ Seq("vpi.cpp", "vpi_register.cpp", "&&") ++
+      Seq("vlib", "work", "&&") ++
+      Seq("vlog") ++ vlogFlags ++ Seq("&&") ++
+      // VSIM is unfortunately unable to run properly anywhere else than the folder where vlib folder was created
+      Seq("cat << EOF", ">", s"$topModule", "&&\n") ++
+      Seq("cd \"\\$( dirname \"\\${BASH_SOURCE[0]}\" )\"\n",
+          "echo \"Args: \\$@\"\n",
+          "sw=0\n",
+          "for arg in \"\\$@\"; do\n",
+          "        if [[ \"\\$arg\" == \"--\" && \\$sw == 0 ]]; then\n",
+          "                sw=1\n",
+          "        elif [[ \\$sw == 0 ]]; then\n",
+          "                vsimArgs+=(\"\\$arg\")\n",
+          "        else\n",
+          "                printf \"%b \" \"\\$arg\" >>", s"$topModule.do", "\n",
+          "        fi\n",
+          "done\n",
+          "echo \"\n\nrun -all\" >>", s"$topModule.do", "\n",
+          "echo \"vsimArgs: \\${vsimArgs[@]}\"\n",
+          "echo \"doCmds:\"\n",
+          "cat", s"$topModule.do", "\n",
+          "vsim", "-64", 
+          "\"\\${vsimArgs[@]}\"",
+          s"-pli ${topModule}.so", 
+          s"test", 
+          "-do", s"$topModule.do", 
+          "\nEOF\n") ++
+      Seq("chmod", "u+x", s"$topModule") mkString " "
+  }
+
+  def composeFlags(
+               topModule: String,
+               dir: java.io.File,
+               moreVlogFlags: Seq[String] = Seq.empty[String],
+               moreVsimCFlags: Seq[String] = Seq.empty[String]): (Seq[String], Seq[String]) = {
+
+    val vlogFlags = Seq(
+      "+define+CLOCK_PERIOD=1",
+    ) ++ moreVlogFlags
+    
+    
+    val cFlags = Seq(
+      s"-o $topModule.so",
+      "-I$QUESTA_INSTALL_DIR/include",
+      "-D__VSIM__",
+      s"-I$dir",
+      "-fPIC",
+      "-std=c++11",
+      "-lc",
+      "-m64",
+      "-lvpi",
+      "-lveriuser",
+      "-Bsymbolic",
+      "-shared"
+    ) ++ moreVsimCFlags
+
+    (vlogFlags, cFlags)
+  }
+
+  def constructCSimulatorCommand(
+    topModule: String,
+    dir: java.io.File,
+    harness:  java.io.File,
+    vlogFlags: Seq[String] = Seq.empty[String],
+    vsimCFlags: Seq[String] = Seq.empty[String]
+  ): String = {
+    val (cFlags, cCFlags) = composeFlags(topModule, dir,
+      vlogFlags ++ blackBoxVerilogList(dir) ++ Seq(s"$topModule.v", harness.toString),
+      vsimCFlags
+    )
+    composeCommand(topModule, dir, cFlags, cCFlags)
+  }
+
+  def apply(
+    topModule: String,
+    dir: java.io.File,
+    vsimHarness: java.io.File,
+    moreVlogFlags: Seq[String] = Seq.empty[String],
+    moreVsimCFlags: Seq[String] = Seq.empty[String],
+    editCommands: String = ""
+  ): ProcessBuilder = {
+    val finalCommand = editCSimulatorCommand(constructCSimulatorCommand(topModule, dir, vsimHarness, moreVlogFlags, moreVsimCFlags), editCommands)
+    println(s"$finalCommand")
+    Seq("bash", "-c", finalCommand)
+  }
+}
+
 private[iotesters] object verilogToVCS extends EditableBuildCSimulatorCommand {
   val prefix = "vcs-command-edit"
   override def composeCommand(
@@ -380,7 +476,7 @@ private[iotesters] object verilogToVerilator extends EditableBuildCSimulatorComm
 }
 
 private[iotesters] case class BackendException(b: String)
-  extends Exception(s"Unknown backend: $b. Backend should be firrtl, verilator, ivl, vcs, or glsim")
+  extends Exception(s"Unknown backend: $b. Backend should be firrtl, verilator, ivl, vsim, vcs, or glsim")
 
 private[iotesters] case class TestApplicationException(exitVal: Int, lastMessage: String)
   extends RuntimeException(lastMessage)
@@ -403,6 +499,9 @@ private[iotesters] object TesterProcess {
     kill(p.simApiInterface)
   }
   def kill(p: VerilatorBackend) {
+    kill(p.simApiInterface)
+  }
+  def kill(p: VSIMBackend) {
     kill(p.simApiInterface)
   }
   def kill(p: FirrtlTerpBackend) {

--- a/src/main/scala/chisel3/iotesters/TesterOptions.scala
+++ b/src/main/scala/chisel3/iotesters/TesterOptions.scala
@@ -29,6 +29,11 @@ case class TesterOptions(
   moreIvlFlags:         Seq[String] = Seq.empty,
   moreIvlCFlags:        Seq[String] = Seq.empty,
   ivlCommandEdits:      String = "",
+  moreVlogFlags:        Seq[String] = Seq.empty,
+  moreVsimCFlags:       Seq[String] = Seq.empty,
+  moreVsimFlags:        Seq[String] = Seq.empty,
+  moreVsimDoCmds:       Seq[String] = Seq.empty,
+  vsimCommandEdits:     String = "",
   generateVcdOutput:    String = "",
   generateFsdbOutput:    String = ""
 ) extends ComposableOptions
@@ -48,7 +53,7 @@ trait HasTesterOptions {
   parser.opt[String]("backend-name").valueName("<firrtl|treadle|verilator|ivl|vcs>")
     .abbr("tbn")
     .validate { x =>
-      if (Array("firrtl", "treadle", "verilator", "ivl", "vcs").contains(x.toLowerCase)) parser.success
+      if (Array("firrtl", "treadle", "verilator", "ivl", "vcs", "vsim").contains(x.toLowerCase)) parser.success
       else parser.failure(s"$x not a legal backend name")
     }
     .foreach { x => testerOptions = testerOptions.copy(backendName = x) }
@@ -87,12 +92,12 @@ trait HasTesterOptions {
   parser.opt[String]("more-vcs-flags")
     .abbr("tmvf")
     .foreach { x => testerOptions = testerOptions.copy(moreVcsFlags = x.split("""\s""")) }
-    .text("Add specified commands to the VCS command line")
+    .text("Add specified commands to the VCS/Verilator command line")
 
   parser.opt[String]("more-vcs-c-flags")
     .abbr("tmvf")
     .foreach { x => testerOptions = testerOptions.copy(moreVcsCFlags = x.split("""\s""")) }
-    .text("Add specified commands to the CFLAGS on the VCS command line")
+    .text("Add specified commands to the CFLAGS on the VCS/Verilator command line")
 
   parser.opt[String]("vcs-command-edits")
     .abbr("tvce")
@@ -114,6 +119,32 @@ trait HasTesterOptions {
     .abbr("tice")
     .foreach { x =>
       testerOptions = testerOptions.copy(ivlCommandEdits = x) }
+    .text("a file containing regex substitutions, one per line s/pattern/replacement/")
+
+  parser.opt[String]("more-vlog-flags")
+    .abbr("tmvlf")
+    .foreach { x => testerOptions = testerOptions.copy(moreVlogFlags = x.split("""\s""")) }
+    .text("Add specified commands to the vlog command line")
+    
+  parser.opt[String]("more-vsim-flags")
+    .abbr("tmvsf")
+    .foreach { x => testerOptions = testerOptions.copy(moreVsimFlags = x.split("""\s""")) }
+    .text("Add specified commands to the vsim command line startup")
+    
+  parser.opt[String]("more-vsim-do-cmds")
+    .abbr("tmvsd")
+    .foreach { x => testerOptions = testerOptions.copy(moreVsimDoCmds = testerOptions.moreVsimDoCmds ++ Seq(x)) }
+    .text("Execute specified commands within vsim interpreter before simulation run")
+
+  parser.opt[String]("more-vsim-c-flags")
+    .abbr("tmvscf")
+    .foreach { x => testerOptions = testerOptions.copy(moreVsimCFlags = x.split("""\s""")) }
+    .text("Add specified commands to the g++ vpi compilation command line for use with vsim backend")
+
+  parser.opt[String]("vsim-command-edits")
+    .abbr("tvsce")
+    .foreach { x =>
+      testerOptions = testerOptions.copy(vsimCommandEdits = x) }
     .text("a file containing regex substitutions, one per line s/pattern/replacement/")
 
   parser.opt[String]("log-file-name")

--- a/src/main/scala/chisel3/iotesters/VSIMBackend.scala
+++ b/src/main/scala/chisel3/iotesters/VSIMBackend.scala
@@ -1,0 +1,191 @@
+// See LICENSE for license details.
+package chisel3.iotesters
+
+import java.io.{File, FileWriter, IOException, Writer}
+import java.nio.file.{FileAlreadyExistsException, Files, Paths}
+import java.nio.file.StandardCopyOption.REPLACE_EXISTING
+
+import chisel3.{ChiselExecutionFailure, ChiselExecutionSuccess, Element, MultiIOModule}
+import firrtl.{ChirrtlForm, CircuitState}
+import firrtl.transforms.BlackBoxTargetDirAnno
+
+/**
+  * Copies the necessary header files used for vlog compilation to the specified destination folder
+  */
+object copyVsimFiles {
+  def apply(destinationDirPath: String): Unit = {
+    new File(destinationDirPath).mkdirs()
+    val simApiHFilePath = Paths.get(destinationDirPath + "/sim_api.h")
+    val vpiHFilePath = Paths.get(destinationDirPath + "/vpi.h")
+    val vpiCppFilePath = Paths.get(destinationDirPath + "/vpi.cpp")
+    val vpiRegFilePath = Paths.get(destinationDirPath + "/vpi_register.cpp")
+    try {
+      Files.createFile(simApiHFilePath)
+      Files.createFile(vpiHFilePath)
+      Files.createFile(vpiCppFilePath)
+      Files.createFile(vpiRegFilePath)
+    } catch {
+      case _: FileAlreadyExistsException =>
+        System.out.format("")
+      case x: IOException =>
+        System.err.format("createFile error: %s%n", x)
+    }
+
+    Files.copy(getClass.getResourceAsStream("/sim_api.h"), simApiHFilePath, REPLACE_EXISTING)
+    Files.copy(getClass.getResourceAsStream("/vpi.h"), vpiHFilePath, REPLACE_EXISTING)
+    Files.copy(getClass.getResourceAsStream("/vpi.cpp"), vpiCppFilePath, REPLACE_EXISTING)
+    Files.copy(getClass.getResourceAsStream("/vpi_register.cpp"), vpiRegFilePath, REPLACE_EXISTING)
+  }
+}
+
+/**
+  * Generates the Module specific vsim harness verilog file for VSIM backend
+  */
+object genVSIMVerilogHarness {
+  def apply(dut: MultiIOModule, writer: Writer) {
+    val dutName = dut.name
+    // getPorts() is going to return names prefixed with the dut name.
+    // These don't correspond to code currently generated for verilog modules,
+    //  so we have to strip the dut name prefix (and the delimiter) from the name.
+    // We tell getPorts() to use "_" as the delimiter to simplify the replacement regexp.
+    def fixnames(portSeq: (Seq[(Element, String)], Seq[(Element, String)])): (Seq[(Element, String)], Seq[(Element, String)]) = {
+      val replaceRegexp = ("^" + dutName + "_").r
+      (
+        portSeq._1 map { case (e: Element, s: String) => (e, replaceRegexp.replaceFirstIn(s, ""))},
+        portSeq._2 map { case (e: Element, s: String) => (e, replaceRegexp.replaceFirstIn(s, ""))}
+      )
+    }
+    val (inputs, outputs) = fixnames(getPorts(dut, "_"))
+
+    writer write "module test;\n"
+    writer write "  reg clock = 1;\n"
+    writer write "  reg reset = 1;\n"
+    inputs foreach { case (node, name) =>
+      if ("clock" != name && "reset" != name) {
+        writer write s"  reg[${node.getWidth-1}:0] $name = 0;\n"
+      }
+    }
+    outputs foreach { case (node, name) =>
+      writer write s"  wire[${node.getWidth-1}:0] $name;\n"
+    }
+
+    writer write "  always #`CLOCK_PERIOD clock = ~clock;\n"
+    writer write "  reg vcdon = 0;\n"
+    writer write "  reg [1023:0] vcdfile = 0;\n"
+
+    writer write "\n  /*** DUT instantiation ***/\n"
+    writer write s"  $dutName $dutName(\n"
+    writer write "    .clock(clock),\n"
+    writer write "    .reset(reset),\n"
+    writer write (((inputs ++ outputs).unzip._2 map (name =>
+        if ("clock" != name && "reset" != name) s"    .$name(${name})" else None)).filter(_ != None) mkString ",\n"
+      )
+    writer write "  );\n\n"
+
+    writer write "  initial begin\n"
+    writer write "    $init_rsts(reset);\n"
+    writer write "    $init_ins(%s);\n".format(inputs.unzip._2 mkString ", ")
+    writer write "    $init_outs(%s);\n".format(outputs.unzip._2 mkString ", ")
+    writer write "    $init_sigs(%s);\n".format(dutName)
+    writer write "    /*** VCD dump ***/\n"
+    writer write "    if ($value$plusargs(\"vcdfile=%s\", vcdfile)) begin\n"
+    writer write "      $dumpfile(vcdfile);\n"
+    writer write "      $dumpvars(0, %s);\n".format(dutName)
+    writer write "      $dumpoff;\n"
+    writer write "      vcdon = 0;\n"
+    writer write "    end\n"
+    writer write "  end\n\n"
+
+    writer write "  always @(posedge clock) begin\n"
+    writer write "    if (vcdfile && reset) begin\n"
+    writer write "      $dumpoff;\n"
+    writer write "      vcdon = 0;\n"
+    writer write "    end\n"
+    writer write "    else if (vcdfile && !vcdon) begin\n"
+    writer write "      $dumpon;\n"
+    writer write "      vcdon = 1;\n"
+    writer write "    end\n"
+    writer write "    $tick();\n"
+    writer write "  end\n\n"
+    writer write "endmodule\n"
+    writer.close()
+  }
+}
+
+private[iotesters] object setupVSIMBackend {
+  def apply[T <: MultiIOModule](dutGen: () => T, optionsManager: TesterOptionsManager): (T, Backend) = {
+    optionsManager.makeTargetDir()
+    optionsManager.chiselOptions = optionsManager.chiselOptions.copy(
+      runFirrtlCompiler = false
+    )
+    val dir = new File(optionsManager.targetDirName)
+
+    // Generate CHIRRTL
+    chisel3.Driver.execute(optionsManager, dutGen) match {
+      case ChiselExecutionSuccess(Some(circuit), emitted, _) =>
+
+        val chirrtl = firrtl.Parser.parse(emitted)
+        val dut = getTopModule(circuit).asInstanceOf[T]
+
+        /*
+        The following block adds an annotation that tells the black box helper where the
+        current build directory is, so that it can copy verilog resource files into the right place
+         */
+        val annotations = optionsManager.firrtlOptions.annotations ++
+          List(BlackBoxTargetDirAnno(optionsManager.targetDirName))
+
+        val transforms = optionsManager.firrtlOptions.customTransforms
+
+        // Generate Verilog
+        val verilogFile = new File(dir, s"${circuit.name}.v")
+        val verilogWriter = new FileWriter(verilogFile)
+
+        val compileResult = (new firrtl.VerilogCompiler).compileAndEmit(
+          CircuitState(chirrtl, ChirrtlForm, annotations),
+          customTransforms = transforms
+        )
+        val compiledStuff = compileResult.getEmittedCircuit
+        verilogWriter.write(compiledStuff.value)
+        verilogWriter.close()
+
+        // Generate Harness
+        val vsimHarnessFileName = s"${circuit.name}-harness.v"
+        val vsimHarnessFile = new File(dir, vsimHarnessFileName)
+        
+        copyVsimFiles(dir.toString)
+        genVSIMVerilogHarness(dut, new FileWriter(vsimHarnessFile))
+        assert(
+          verilogToVSIM(circuit.name, dir, new File(vsimHarnessFileName),
+            moreVlogFlags = optionsManager.testerOptions.moreVlogFlags,
+            moreVsimCFlags = optionsManager.testerOptions.moreVsimCFlags,
+            editCommands = optionsManager.testerOptions.vsimCommandEdits
+          ).! == 0)
+
+        val command = if(optionsManager.testerOptions.testCmd.nonEmpty) {
+          optionsManager.testerOptions.testCmd
+        } else {
+          val vcdFile = if(optionsManager.testerOptions.generateVcdOutput != "off") Seq(s"+vcdfile=${circuit.name}.vcd") else Seq()
+          val trace = if(optionsManager.testerOptions.isVerbose) Seq("-trace_foreign", "1") else Seq()
+          val flags = if (optionsManager.testerOptions.moreVsimFlags contains "-gui" ) {
+            optionsManager.testerOptions.moreVsimFlags
+          } else {
+            Seq("-c") ++ optionsManager.testerOptions.moreVsimFlags
+          }
+          
+          Seq(new File(dir, circuit.name).toString) ++ 
+          vcdFile ++ trace ++ flags ++
+          Seq("--") ++ optionsManager.testerOptions.moreVsimDoCmds
+        }
+        println(command)
+
+        (dut, new VSIMBackend(dut, command))
+      case ChiselExecutionFailure(message) =>
+        throw new Exception(message)
+    }
+  }
+}
+
+private[iotesters] class VSIMBackend(dut: MultiIOModule,
+                                    cmd: Seq[String],
+                                    _seed: Long = System.currentTimeMillis)
+           extends VerilatorBackend(dut, cmd, _seed)


### PR DESCRIPTION
Enable the use of Modelsim/Questasim as backend with chisel-tester

I am not really proud of adding suport for another commercial simulator but it is an important milestone for us to push forward the integration of chisel within our existing code base.
We indeed rely on lots of existing systemverilog libraries that are not supported with verilator.

I hope it will help other people as well.

I have started to test this new backend on my side but I have no idea how to integrate proper tests due to the very nature of vsim as closed-source commercial simulator.
Maybe use the same syntax as for vcs ?
`assume(firrtl.FileUtils.isVCSAvailable)`
I cannot say that it doesn't break vcs backend either as I cannot test it but other tests are still passing.

I think some of the changes of the vpi code could apply to other backends as well.