### PR TITLE
Interval fixedpoint fixes

### DIFF
--- a/src/main/scala/chisel3/iotesters/VerilatorBackend.scala
+++ b/src/main/scala/chisel3/iotesters/VerilatorBackend.scala
@@ -6,7 +6,7 @@ import java.nio.file.StandardCopyOption.REPLACE_EXISTING
 import java.nio.file.{FileAlreadyExistsException, Files, Paths}
 
 import chisel3._
-import chisel3.experimental.FixedPoint
+import chisel3.experimental.{FixedPoint, Interval}
 import chisel3.internal.InstanceId
 import firrtl._
 import firrtl.annotations.CircuitName
@@ -322,9 +322,9 @@ private[iotesters] class VerilatorBackend(dut: MultiIOModule,
     }
 
     val result = signal match {
-      case s: SInt =>
-        signConvert(bigIntU, s.getWidth)
+      case s: SInt       => signConvert(bigIntU, s.getWidth)
       case f: FixedPoint => signConvert(bigIntU, f.getWidth)
+      case i: Interval   => signConvert(bigIntU, i.getWidth)
       case _ => bigIntU
     }
     if (verbose) logger info s"  PEEK $path -> ${bigIntToStr(result, base)}"

--- a/src/test/scala/examples/IntervalSpec.scala
+++ b/src/test/scala/examples/IntervalSpec.scala
@@ -1,0 +1,108 @@
+// See LICENSE for license details.
+
+package examples
+
+import chisel3._
+import chisel3.experimental._
+import chisel3.iotesters.PeekPokeTester
+import org.scalatest.{FreeSpec, Matchers}
+
+class IntervalReduce(val intervalType: Interval, val size: Int) extends Module {
+  val io = IO(new Bundle {
+    val in = Input(Vec(size, intervalType))
+    val sum = Output(intervalType)
+  })
+
+  io.sum := io.in.reduce(_ + _).squeeze(io.sum)
+}
+
+class IntervalReduceTester(c: IntervalReduce, useBigDecimal: Boolean = true) extends PeekPokeTester(c) {
+  private val nums = (0 until c.size).map { _ => 0.1 }
+
+  println(s"nums ${nums.mkString(", ")}")
+
+  nums.zipWithIndex.foreach { case (num, index) =>
+    pokeInterval(c.io.in(index), num)
+  }
+
+  step(1)
+
+  if (useBigDecimal) {
+    val result = peekIntervalBig(c.io.sum)
+    println(s"peek got $result")
+
+    expectIntervalBig(c.io.sum, BigDecimal("1.000000000000000052041704279304213"), "")
+  } else {
+    // The following should generate a ChiselException, losing precision trying to represent a value as a Double.
+    println(s"peek got ${peekInterval(c.io.sum)}")
+  }
+}
+
+class IntervalDivide(val intervalType: Interval, val shiftAmount: Int) extends Module {
+  val io = IO(new Bundle {
+    val in = Input(intervalType)
+    val out = Output(intervalType)
+  })
+
+  io.out := (io.in.asUInt >> shiftAmount).asInterval(intervalType.range)
+}
+
+class IntervalDivideTester(c: IntervalDivide) extends PeekPokeTester(c) {
+  for(d <- 0.0 to 15.0 by (1.0 / 3.0)) {
+    pokeInterval(c.io.in, d)
+
+
+    step(1)
+
+    println(s"$d >> 2 => ${peekInterval(c.io.out)}")
+    expectInterval(c.io.out, d / 4.0, s"${c.io.out.name} got ${peekInterval(c.io.out)} expected ${d / 4.0}")
+  }
+}
+
+class IntervalSpec extends FreeSpec with Matchers {
+  val useBigDecimal = true
+  val flags = Array("--backend-name", "treadle")
+  "interval reduce should work with BigDecimal" in {
+    iotesters.Driver.execute(flags, () => new IntervalReduce(Interval(70.W, 60.BP), 10)) { c =>
+      new IntervalReduceTester(c, useBigDecimal)
+    } should be (true)
+  }
+
+  "interval reduce should fail without BigDecimal" in {
+    (the[ChiselException] thrownBy {
+      iotesters.Driver.execute(flags, () => new IntervalReduce(Interval(70.W, 60.BP), 10)) { c =>
+        new IntervalReduceTester(c, !useBigDecimal)
+      }
+    }).getMessage should include ("is too big, precision lost with > 53 bits")
+  }
+
+  "with enough bits interval pseudo divide should work" in {
+    iotesters.Driver.execute(flags, () => new IntervalDivide(Interval(64.W, 32.BP), 2)) { c =>
+      new IntervalDivideTester(c)
+    } should be (true)
+  }
+  "not enough bits and interval pseudo divide will not work" in {
+    iotesters.Driver.execute(flags, () => new IntervalDivide(Interval(10.W, 4.BP), 2)) { c =>
+      new IntervalDivideTester(c)
+    } should be (false)
+  }
+
+  "negative numbers can be read back from verilator" in {
+    iotesters.Driver.execute(
+      Array("--backend-name", "verilator"),
+      () => new MultiIOModule {
+        val in  = IO(Input(Interval(range"[-64.0,64.0).2")))
+        val out = IO(Output(Interval(range"[-64.0,64.0).2")))
+        out := in
+      }
+    ) { c =>
+      new PeekPokeTester(c) {
+        for(bd <- BigDecimal(-64.0) until BigDecimal(64.0) by 0.25) {
+          pokeInterval(c.in, bd.toDouble)
+          step(1)
+          expectInterval(c.out, bd.toDouble, "pass through values should be the same")
+        }
+      }
+    } should be (true)
+  }
+}


### PR DESCRIPTION
This fixes a problem with not providing handle for peeking intervals
And fixes a bug with extra high bits poked to simulator when using
negative numbers with fixedpoint and intervals to the verilator backend