### PR TITLE
Fix chiselMain.apply with tests gets None.get

### DIFF
--- a/src/main/scala/chisel3/iotesters/Driver.scala
+++ b/src/main/scala/chisel3/iotesters/Driver.scala
@@ -12,7 +12,7 @@ import logger.Logger
 import scala.util.DynamicVariable
 
 object Driver {
-  private val backendVar = new DynamicVariable[Option[Backend]](None)
+  private[iotesters] val backendVar = new DynamicVariable[Option[Backend]](None)
   private[iotesters] def backend = backendVar.value
 
   private val optionsManagerVar = new DynamicVariable[Option[TesterOptionsManager]](None)

--- a/src/test/scala/examples/ChiselTestMain.scala
+++ b/src/test/scala/examples/ChiselTestMain.scala
@@ -1,0 +1,36 @@
+package examples
+
+import chisel3._
+import chisel3.iotesters._
+
+/**
+  * Test module for chiselMainTest and chiselMain.apply with test
+  */
+class TestModule extends Module {
+  val io = IO(new Bundle {
+    val in = Input(Bool())
+    val out = Output(Bool())
+  })
+
+  io.out := io.in
+}
+
+/**
+  * Example of iotesters.chiselMainTest
+  */
+object chiselMainTest extends App {
+
+  iotesters.chiselMainTest(
+    Array(
+      "--targetDir", "test_run_dir/test",
+      "--verilator",
+      //"--v",
+      //"--genHarness",
+      //"--compile",
+      "--test"), () => new TestModule) {
+    c => new PeekPokeTester(c) {
+      poke(c.io.in, true)
+      expect(c.io.out, true)
+    }
+  }
+}


### PR DESCRIPTION
When I use chiselMainTest with --test option, I get None.get from below code because Driver.backendVar didn't set.
So this PR fixed that bug as following code modifications.

- change variable accessibility in Driver.
  - Driver.backendVar can't access from outside Driver object, so add `[iotesters]`.
- add code to set Driver.backendVar in chiselMain.apply method.