### PR TITLE
Fix chisel main with tests

### DIFF
--- a/src/main/scala/chisel3/iotesters/ChiselMain.scala
+++ b/src/main/scala/chisel3/iotesters/ChiselMain.scala
@@ -4,11 +4,11 @@ package chisel3.iotesters
 
 import java.io.{File, FileWriter, IOException}
 import java.nio.file.{FileAlreadyExistsException, Files, Paths}
+
 import scala.collection.mutable.ArrayBuffer
 import scala.util.DynamicVariable
-
 import chisel3._
-
+import chisel3.iotesters.Driver.backendVar
 import firrtl.FileUtils
 
 private[iotesters] class TesterContext {
@@ -187,19 +187,22 @@ object chiselMain {
       val dut = elaborate(args, dutGen)
       if (context.isRunTest) {
         setupBackend(dut)
-        assert(try {
-          testerGen(dut).finish
-        } catch { case e: Throwable =>
-          e.printStackTrace()
-          context.backend match {
-            case Some(b: VCSBackend) =>
-              TesterProcess kill b
-            case Some(b: VerilatorBackend) =>
-              TesterProcess kill b
-            case _ =>
-          }
-          false
-        }, "Test failed")
+
+        backendVar.withValue(Some(context.backend.get)) {
+          assert(try {
+            testerGen(dut).finish
+          } catch { case e: Throwable =>
+            e.printStackTrace()
+            context.backend match {
+              case Some(b: VCSBackend) =>
+                TesterProcess kill b
+              case Some(b: VerilatorBackend) =>
+                TesterProcess kill b
+              case _ =>
+            }
+            false
+          }, "Test failed")
+        }
       }
       dut
     }

--- a/src/main/scala/chisel3/iotesters/Driver.scala
+++ b/src/main/scala/chisel3/iotesters/Driver.scala
@@ -12,7 +12,7 @@ import logger.Logger
 import scala.util.DynamicVariable
 
 object Driver {
-  private val backendVar = new DynamicVariable[Option[Backend]](None)
+  private[iotesters] val backendVar = new DynamicVariable[Option[Backend]](None)
   private[iotesters] def backend = backendVar.value
 
   private val optionsManagerVar = new DynamicVariable[Option[TesterOptionsManager]](None)

--- a/src/test/scala/examples/ChiselTestMain.scala
+++ b/src/test/scala/examples/ChiselTestMain.scala
@@ -1,0 +1,43 @@
+package examples
+
+import java.nio.file.{Paths, Files}
+
+import chisel3._
+import chisel3.iotesters._
+import org.scalatest.{FreeSpec, Matchers}
+
+/**
+  * Test module for chiselMainTest and chiselMain.apply with test
+  */
+class TestModule extends Module {
+  val io = IO(new Bundle {
+    val in = Input(Bool())
+    val out = Output(Bool())
+  })
+
+  io.out := io.in
+}
+
+/**
+  * Example of iotesters.chiselMainTest
+  */
+object ChiselMainTest extends App {
+
+  val testDir = Paths.get("test_run_dir", "test")
+
+  if (Files.notExists(testDir)) Files.createDirectories(testDir)
+
+  iotesters.chiselMainTest(
+    Array(
+      "--targetDir", testDir.toString,
+      "--verilator",
+      "--v",
+      "--genHarness",
+      "--compile",
+      "--test"), () => new TestModule) {
+    c => new PeekPokeTester(c) {
+      poke(c.io.in, true)
+      expect(c.io.out, true)
+    }
+  }
+}


### PR DESCRIPTION
When I use `chiselMainTest` with `--test` option, I get None.get from below code because Driver.backendVar doesn't set.
This PR is to fix that bug as following code modifications.

- change variable accessibility in Driver.
  - `Driver.backendVar` can't access from outside Driver object, so add `[iotesters]`.
- add code to set `Driver.backendVar` in `chiselMain.apply` method.
- add example for `chiselMainTest`.