### PR TITLE
Features to enable FFT development

### DIFF
--- a/src/main/scala/chisel3/iotesters/Driver.scala
+++ b/src/main/scala/chisel3/iotesters/Driver.scala
@@ -29,7 +29,8 @@ object Driver {
     */
   def execute[T <: MultiIOModule](
                             dutGenerator: () => T,
-                            optionsManager: TesterOptionsManager
+                            optionsManager: TesterOptionsManager,
+                            firrtlSourceOverride: Option[String] = None
                           )
                           (
                             testerGen: T => PeekPokeTester[T]
@@ -48,11 +49,11 @@ object Driver {
 
         val (dut, backend) = testerOptions.backendName match {
           case "firrtl" =>
-            setupFirrtlTerpBackend(dutGenerator, optionsManager)
+            setupFirrtlTerpBackend(dutGenerator, optionsManager, firrtlSourceOverride)
           case "treadle" =>
             setupTreadleBackend(dutGenerator, optionsManager)
           case "verilator" =>
-            setupVerilatorBackend(dutGenerator, optionsManager)
+            setupVerilatorBackend(dutGenerator, optionsManager, firrtlSourceOverride)
           case "ivl" =>
             setupIVLBackend(dutGenerator, optionsManager)
           case "vcs" =>

--- a/src/main/scala/chisel3/iotesters/FirrtlTerpBackend.scala
+++ b/src/main/scala/chisel3/iotesters/FirrtlTerpBackend.scala
@@ -118,7 +118,9 @@ private[iotesters] class FirrtlTerpBackend(
 private[iotesters] object setupFirrtlTerpBackend {
   def apply[T <: MultiIOModule](
       dutGen: () => T,
-      optionsManager: TesterOptionsManager = new TesterOptionsManager): (T, Backend) = {
+      optionsManager: TesterOptionsManager = new TesterOptionsManager with HasInterpreterOptions,
+      firrtlSourceOverride: Option[String] = None
+  ): (T, Backend) = {
 
     // the backend must be firrtl if we are here, therefore we want the firrtl compiler
     optionsManager.firrtlOptions = optionsManager.firrtlOptions.copy(compilerName = "low")
@@ -137,7 +139,8 @@ private[iotesters] object setupFirrtlTerpBackend {
         val dut = getTopModule(circuit).asInstanceOf[T]
         firrtlExecutionResult match {
           case FirrtlExecutionSuccess(_, compiledFirrtl) =>
-            (dut, new FirrtlTerpBackend(dut, compiledFirrtl, optionsManager = optionsManager))
+            val firrtlText = firrtlSourceOverride.getOrElse(compiledFirrtl)
+            (dut, new FirrtlTerpBackend(dut, firrtlText, optionsManager = optionsManager))
           case FirrtlExecutionFailure(message) =>
             throw new Exception(s"FirrtlBackend: failed firrlt compile message: $message")
         }

--- a/src/main/scala/chisel3/iotesters/VerilatorBackend.scala
+++ b/src/main/scala/chisel3/iotesters/VerilatorBackend.scala
@@ -205,7 +205,9 @@ int main(int argc, char **argv, char **env) {
 }
 
 private[iotesters] object setupVerilatorBackend {
-  def apply[T <: MultiIOModule](dutGen: () => T, optionsManager: TesterOptionsManager): (T, Backend) = {
+  def apply[T <: MultiIOModule](dutGen: () => T,
+                                optionsManager: TesterOptionsManager,
+                                firrtlSourceOverride: Option[String] = None): (T, Backend) = {
     import firrtl.{ChirrtlForm, CircuitState}
 
     optionsManager.makeTargetDir()
@@ -220,7 +222,8 @@ private[iotesters] object setupVerilatorBackend {
     chisel3.Driver.execute(optionsManager, dutGen) match {
       case ChiselExecutionSuccess(Some(circuit), emitted, _) =>
 
-        val chirrtl = firrtl.Parser.parse(emitted)
+        val chirrtlSource = firrtlSourceOverride.getOrElse(emitted)
+        val chirrtl = firrtl.Parser.parse(chirrtlSource)
         val dut = getTopModule(circuit).asInstanceOf[T]
 
         val suppressVerilatorVCD = optionsManager.testerOptions.generateVcdOutput == "off"


### PR DESCRIPTION
Add ability to pass an override to firrtl source down to the firrtl interpreter and to Verilator.
This functionality was used as part of the FFT Craft project but was never PR'd. The FFT
is being redone and this functionality is needed for testing and compatibility with earlier work
This is should probably be done in a better way using stage phase, so consider that a todo