### PR TITLE
Next major will be 2.5

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,7 @@ def javacOptionsVersion(scalaVersion: String): Seq[String] = {
 }
 
 organization := "edu.berkeley.cs"
-version := "1.6-SNAPSHOT"
+version := "2.5-SNAPSHOT"
 name := "chisel-iotesters"
 
 scalaVersion := "2.12.10"

--- a/build.sc
+++ b/build.sc
@@ -15,7 +15,7 @@ trait CrossUnRootedSbtModule extends CrossSbtModule {
 }
 
 trait CommonModule extends CrossUnRootedSbtModule with PublishModule {
-  def publishVersion = "1.5-SNAPSHOT"
+  def publishVersion = "2.5-SNAPSHOT"
 
   def pomSettings = PomSettings(
     description = artifactName(),


### PR DESCRIPTION
Change build.sbt and build.sc to consider next major to be 2.5 instead
of 1.6. This brings it inline with all other main repos being x.5
After this PR is merged dsptools will need to be updated