### PR TITLE
Show message returned in ChiselExecutionFailure

### DIFF
--- a/src/main/scala/chisel3/iotesters/FirrtlTerpBackend.scala
+++ b/src/main/scala/chisel3/iotesters/FirrtlTerpBackend.scala
@@ -143,10 +143,12 @@ private[iotesters] object setupFirrtlTerpBackend {
             val firrtlText = firrtlSourceOverride.getOrElse(compiledFirrtl)
             (dut, new FirrtlTerpBackend(dut, firrtlText, optionsManager = optionsManager))
           case FirrtlExecutionFailure(message) =>
-            throw new Exception(s"FirrtlBackend: failed firrlt compile message: $message")
+            throw new Exception(s"FirrtlBackend: failed firrtl compile message: $message")
         }
-      case _ =>
-        throw new Exception("Problem with compilation")
+      case ChiselExecutionFailure(message) =>
+        throw new Exception(s"Problem with compilation in Firrtl Interpreter: $message")
+      case badResult =>
+        throw new Exception(s"Unknown problem with compilation in Firrtl Interpreter, result: ${badResult.toString}")
     }
   }
 }


### PR DESCRIPTION
FirrtlInterpreter backend was eating this message
This will fix that. 
Addresses [Chisel3 Issue #1889](https://github.com/chipsalliance/chisel3/issues/1889)