### PR TITLE
Add support for 2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,23 +8,9 @@ enablePlugins(GhpagesPlugin)
 
 git.remoteRepo := "git@github.com:freechipsproject/chisel-testers.git"
 
-def scalacOptionsVersion(scalaVersion: String): Seq[String] = {
-  Seq() ++ {
-    // If we're building with Scala > 2.11, enable the compile option
-    //  switch to support our anonymous Bundle definitions:
-    //  https://github.com/scala/bug/issues/10047
-    CrossVersion.partialVersion(scalaVersion) match {
-      case Some((2, scalaMajor: Long)) if scalaMajor < 12 => Seq()
-      case _ => Seq("-Xsource:2.11")
-    }
-  }
-}
-
 def javacOptionsVersion(scalaVersion: String): Seq[String] = {
   Seq() ++ {
     // Scala 2.12 requires Java 8. We continue to generate
-    //  Java 7 compatible code for Scala 2.11
-    //  for compatibility with old clients.
     CrossVersion.partialVersion(scalaVersion) match {
       case Some((2, scalaMajor: Long)) if scalaMajor < 12 =>
         Seq("-source", "1.7", "-target", "1.7")
@@ -38,9 +24,9 @@ organization := "edu.berkeley.cs"
 version := "2.5-SNAPSHOT"
 name := "chisel-iotesters"
 
-scalaVersion := "2.12.13"
+scalaVersion := "2.12.14"
 
-crossScalaVersions := Seq("2.12.13")
+crossScalaVersions := Seq("2.12.14", "2.13.6")
 
 // Provide a managed dependency on X if -DXVersion="" is supplied on the command line.
 // The following are the default development versions, not the "release" versions.
@@ -106,8 +92,6 @@ resolvers ++= Seq(
   Resolver.sonatypeRepo("releases")
 )
 
-scalacOptions := Seq("-deprecation") ++ scalacOptionsVersion(scalaVersion.value)
-
 scalacOptions in (Compile, doc) ++= Seq(
   "-diagrams",
   "-diagrams-max-classes", "25",
@@ -115,4 +99,4 @@ scalacOptions in (Compile, doc) ++= Seq(
   "-doc-source-url", "https://github.com/ucb-bar/chisel-testers/tree/master/€{FILE_PATH}.scala"
 )
 
-javacOptions ++= javacOptionsVersion(scalaVersion.value)
+javacOptions ++= Seq("-source", "1.8", "-target", "1.8")

--- a/build.sc
+++ b/build.sc
@@ -47,7 +47,7 @@ trait CommonModule extends CrossUnRootedSbtModule with PublishModule {
   override def javacOptions = CommonBuild.javacOptionsVersion(crossScalaVersion)
 }
 
-val crossVersions = Seq("2.12.13")
+val crossVersions = Seq("2.12.14", "2.13.6")
 
 // Make this available to external tools.
 object chiselTesters extends Cross[ChiselTestersModule](crossVersions: _*) {

--- a/src/main/scala/chisel3/iotesters/FirrtlTerpBackend.scala
+++ b/src/main/scala/chisel3/iotesters/FirrtlTerpBackend.scala
@@ -133,7 +133,7 @@ private[iotesters] object setupFirrtlTerpBackend {
       optionsManager.interpreterOptions = optionsManager.interpreterOptions.copy(writeVCD = true)
     }
 
-    val annos = Driver.filterAnnotations(firrtl.Driver.getAnnotations(optionsManager))
+    val annos = chisel3.iotesters.Driver.filterAnnotations(firrtl.Driver.getAnnotations(optionsManager).toSeq)
     optionsManager.firrtlOptions = optionsManager.firrtlOptions.copy(annotations = annos.toList)
     DriverCompatibility.execute(optionsManager, dutGen) match {
       case ChiselExecutionSuccess(Some(circuit), _, Some(firrtlExecutionResult)) =>

--- a/src/main/scala/chisel3/iotesters/IVLBackend.scala
+++ b/src/main/scala/chisel3/iotesters/IVLBackend.scala
@@ -149,7 +149,7 @@ private[iotesters] object setupIVLBackend {
 
         val compileResult = (new firrtl.VerilogCompiler).compileAndEmit(
           CircuitState(chirrtl, ChirrtlForm, annotations),
-          customTransforms = transforms
+          customTransforms = transforms.toSeq
         )
         val compiledStuff = compileResult.getEmittedCircuit
         verilogWriter.write(compiledStuff.value)

--- a/src/main/scala/chisel3/iotesters/OrderedDecoupledHWIOTester.scala
+++ b/src/main/scala/chisel3/iotesters/OrderedDecoupledHWIOTester.scala
@@ -249,7 +249,7 @@ abstract class OrderedDecoupledHWIOTester extends HWIOTester {
                                             events           : ArrayBuffer[TestingEvent]
                                           ): Map[Data, Vec[UInt]] = {
     val port_vector_events = referenced_ports.map { port =>
-      port -> VecInit(events.map { event => (event.port_values.getOrElse(port, BigInt(0))).asUInt } ++ List(0.U)) //0 added to end
+      port -> VecInit((events.map { event => (event.port_values.getOrElse(port, BigInt(0))).asUInt } ++ List(0.U)).toSeq) //0 added to end
     }.toMap
 
     logScalaDebug(s"Input controller ${io_info.port_to_name(io_interface)} : ports " +

--- a/src/main/scala/chisel3/iotesters/PeekPokeTester.scala
+++ b/src/main/scala/chisel3/iotesters/PeekPokeTester.scala
@@ -224,7 +224,9 @@ abstract class PeekPokeTester[+T <: Module](
   private def getBundleElement(path: List[String], bundle: ListMap[String, Data]): Element = {
     (path, bundle(path.head)) match {
       case (head :: Nil, element: Element) => element
-      case (head :: tail, b: Bundle) => getBundleElement(tail, b.elements)
+      case (head :: tail, b: Bundle) =>
+        val listMap = new ListMap[String, Data] ++ b.elements
+        getBundleElement(tail, listMap)
       case _ => throw new Exception(s"peek/poke bundle element mismatch $path")
     }
   }
@@ -238,7 +240,8 @@ abstract class PeekPokeTester[+T <: Module](
     val circuitElements = signal.elements
     for ( (key, value) <- map) {
       val subKeys = key.split('.').toList
-      val element = getBundleElement(subKeys, circuitElements)
+      val listMap = new ListMap[String, Data] ++ circuitElements
+      val element = getBundleElement(subKeys, listMap)
       element match {
         case Pokeable(e) => poke(e, value)
         case _ => throw new Exception(s"Cannot poke type ${element.getClass.getName}")

--- a/src/main/scala/chisel3/iotesters/SteppedHWIOTester.scala
+++ b/src/main/scala/chisel3/iotesters/SteppedHWIOTester.scala
@@ -125,7 +125,7 @@ abstract class SteppedHWIOTester extends HWIOTester {
       test_actions.map { step =>
         default_value = step.input_map.getOrElse(input_port, default_value)
         (default_value).asUInt(input_port.getWidth.W)
-      }
+      }.toSeq
     )
     input_port := input_values(counter.value)
   }
@@ -134,12 +134,12 @@ abstract class SteppedHWIOTester extends HWIOTester {
     val output_values = VecInit(
       test_actions.map { step =>
         step.output_map.getOrElse(output_port, BigInt(0)).asUInt.asTypeOf(output_port.cloneType )
-      }
+      }.toSeq
     )
     val ok_to_test_output_values = VecInit(
       test_actions.map { step =>
         (step.output_map.contains(output_port)).asBool
-      }
+      }.toSeq
     )
 
     when(ok_to_test_output_values(counter.value)) {

--- a/src/main/scala/chisel3/iotesters/VCSBackend.scala
+++ b/src/main/scala/chisel3/iotesters/VCSBackend.scala
@@ -163,7 +163,7 @@ private[iotesters] object setupVCSBackend {
 
         val compileResult = (new firrtl.VerilogCompiler).compileAndEmit(
           CircuitState(chirrtl, ChirrtlForm, annotations),
-          customTransforms = transforms
+          customTransforms = transforms.toSeq
         )
         val compiledStuff = compileResult.getEmittedCircuit
         verilogWriter.write(compiledStuff.value)

--- a/src/main/scala/chisel3/iotesters/VSIMBackend.scala
+++ b/src/main/scala/chisel3/iotesters/VSIMBackend.scala
@@ -147,7 +147,7 @@ private[iotesters] object setupVSIMBackend {
 
         val compileResult = (new firrtl.VerilogCompiler).compileAndEmit(
           CircuitState(chirrtl, ChirrtlForm, annotations),
-          customTransforms = transforms
+          customTransforms = transforms.toSeq
         )
         val compiledStuff = compileResult.getEmittedCircuit
         verilogWriter.write(compiledStuff.value)

--- a/src/main/scala/chisel3/iotesters/VerilatorBackend.scala
+++ b/src/main/scala/chisel3/iotesters/VerilatorBackend.scala
@@ -246,8 +246,8 @@ private[iotesters] object setupVerilatorBackend {
         val verilogWriter = new FileWriter(verilogFile)
 
         val compileResult = (new firrtl.VerilogCompiler).compileAndEmit(
-          CircuitState(chirrtl, ChirrtlForm, annotations),
-          customTransforms = transforms
+          CircuitState(chirrtl, ChirrtlForm, annotations.toSeq),
+          customTransforms = transforms.toSeq
         )
         val compiledStuff = compileResult.getEmittedCircuit
         verilogWriter.write(compiledStuff.value)
@@ -259,7 +259,7 @@ private[iotesters] object setupVerilatorBackend {
         val cppHarnessWriter = new FileWriter(cppHarnessFile)
         val vcdFile = new File(dir, s"${circuit.name}.vcd")
         val emittedStuff = VerilatorCppHarnessGenerator.codeGen(
-          dut, CircuitState(chirrtl, ChirrtlForm, annotations), vcdFile.toString
+          dut, CircuitState(chirrtl, ChirrtlForm, annotations.toSeq), vcdFile.toString
         )
         cppHarnessWriter.append(emittedStuff)
         cppHarnessWriter.close()

--- a/src/test/scala/examples/FixedIsWholeTester.scala
+++ b/src/test/scala/examples/FixedIsWholeTester.scala
@@ -29,8 +29,8 @@ class FixedIsWholeTestBench(dut: FixedIsWhole) extends PeekPokeTester(dut) {
     pokeFixedPoint(dut.io.in, i.toDouble)
     step(1)
     val result = peek(dut.io.out)
-    println(s"input $i expecting ${i.isWhole()} got $result")
-    expect(dut.io.out, i.isWhole())
+    println(s"input $i expecting ${i.isWhole} got $result")
+    expect(dut.io.out, i.isWhole)
   }
 }
 

--- a/src/test/scala/examples/FixedPointSpec.scala
+++ b/src/test/scala/examples/FixedPointSpec.scala
@@ -51,7 +51,8 @@ class FixedPointDivide(val fixedType: FixedPoint, val shiftAmount: Int) extends 
 }
 
 class FixedPointDivideTester(c: FixedPointDivide) extends PeekPokeTester(c) {
-  for(d <- 0.0 to 15.0 by (1.0 / 3.0)) {
+  for(bd <- BigDecimal(0.0) to 15.0 by (1.0 / 3.0)) {
+    val d = bd.toDouble
     pokeFixedPoint(c.io.in, d)
 
 

--- a/src/test/scala/examples/IntervalSpec.scala
+++ b/src/test/scala/examples/IntervalSpec.scala
@@ -49,7 +49,8 @@ class IntervalDivide(val intervalType: Interval, val shiftAmount: Int) extends M
 }
 
 class IntervalDivideTester(c: IntervalDivide) extends PeekPokeTester(c) {
-  for(d <- 0.0 to 15.0 by (1.0 / 3.0)) {
+  for(bd <- BigDecimal(0.0) to 15.0 by (1.0 / 3.0)) {
+    val d = bd.toDouble
     pokeInterval(c.io.in, d)
 
 


### PR DESCRIPTION
Add support for 2.13, drop relics from 2.11
- Updated build.sbt
  - Removed `-Xsource:2.11` stuff
  - Update scalaVersion and CrossScalaVersions

- Mostly add a bunch of `toSeq`s where needed
- Created some intermediate `ListMap`s where needed